### PR TITLE
Features/177682091 config module

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,62 @@ Easy to use SDK for the DSNP
 
 ## Quick Start
 
-- `npm install @unfinishedlabs/sdk`
-- Import:
-  - `import * as dsnp from "@unfinishedlabs/sdk";`
-  - `import { Announcement } from "@unfinishedlabs/sdk";`
-  - `import { batch } from "@unfinishedlabs/sdk/Announcement";`
-- Require:
-  - `const dsnp = require("@unfinishedlabs/sdk");`
-  - `const { Announcement } = require("@unfinishedlabs/sdk");`
-  - `const { batch } = require("@unfinishedlabs/sdk/Announcement");`
+### Install the package
+
+First, install the SDK package with the following command:
+
+```bash
+npm install @unfinishedlabs/sdk
+```
+
+### Configure the SDK
+
+#### Configuration File
+
+Next, add a `.dsnp.config.js` file to your project's root directory. For web3, the following contents will work:
+
+```js
+var Web3 = require("web3");
+var web3 = new Web3();
+
+var provider = new Web3.providers.HttpProvider("<ETH NODE HTTP ADDRESS>");
+web3.setProvider(provider);
+
+var account = web3.eth.accounts.privateKeyToAccount("<ETH PRIVATE KEY>");
+web3.eth.accounts.wallet.add(account);
+
+module.exports = {
+  accountAddress: account.address,
+  provider: web3
+};
+```
+
+#### Runtime Configuration
+
+Alternatively, the configuration can be set at runtime with the following:
+
+```js
+var config = require("@unfinishedlabs/sdk/Config");
+
+config
+  .setConfig({
+    accountAddress: "<ACCOUNT ADDRESS HERE>",
+    provider: web3
+  })
+  .then(function () {
+    // Do something with the SDK
+  });
+```
+
+## Usage
+
+Once the SDK is installed and configured, the following code can be used to post a batch on the chain:
+
+```js
+var announcement = require("@unfinishedlabs/sdk/Announcement");
+
+announcement.batch("<URI of batch file>", "<Hash of batch file>");
+```
 
 ## Documentation
 
@@ -36,11 +83,11 @@ Documentation is deployed on merge to main to GitHub Pages: https://libertydsnp.
 
 ## Environment Variables
 
-| Name  | Description |
-| --- | ------- | 
-| RPC_URL | url of node to make calls to | 
-| BATCH_CONTRACT_ADDRESS | Address of contract on chain you are calling to | 
-| TESTING_PRIVATE_KEY| **Only used in testing** - private key of account you are sending transactions from  | 
+| Name                   | Description                                                                         |
+| ---------------------- | ----------------------------------------------------------------------------------- |
+| RPC_URL                | url of node to make calls to                                                        |
+| BATCH_CONTRACT_ADDRESS | Address of contract on chain you are calling to                                     |
+| TESTING_PRIVATE_KEY    | **Only used in testing** - private key of account you are sending transactions from |
 
 ## How to Test
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install @unfinishedlabs/sdk
 
 #### Configuration File
 
-Next, add a `.dsnp.config.js` file to your project's root directory. For web3, the following contents will work:
+Next, add a `dsnp.config.js` file to your project's root directory. For web3, the following contents will work:
 
 ```js
 var Web3 = require("web3");

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -53,8 +53,8 @@ describe("config", () => {
 
         // We have to test keys here because #toMatchObject doesn't work with
         // object instances
-        expect(results["store"]).toBeInstanceOf(Object);
         expect(results["queue"]).toBeInstanceOf(Object);
+        expect(results["store"]).toBeInstanceOf(Object);
       });
 
       it("fetches the current config settings", async () => {

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1,0 +1,48 @@
+import MemoryStore from "../storage/memoryStorage";
+import MemoryQueue from "../batch/memoryQueue";
+import { getConfig, setConfig, Config } from "./config";
+
+describe("config", () => {
+  describe("#getConfig", () => {
+    it("returns the default settings when the config hasn't been set yet", () => {
+      expect(getConfig()).toMatchObject({
+        store: MemoryStore(),
+        queue: MemoryQueue(),
+      });
+    });
+
+    it("fetches the current config settings", () => {
+      const testConfig = ({
+        test: "object",
+      } as unknown) as Config;
+
+      setConfig(testConfig);
+
+      expect(getConfig()).toMatchObject({ test: "object" });
+    });
+
+    it("overrides the returned settings with any provided parameters", () => {
+      const testConfig = ({
+        test: "object",
+      } as unknown) as Config;
+
+      setConfig(testConfig);
+
+      expect(getConfig(({ test: "differentObject" } as unknown) as Config)).toMatchObject({
+        test: "differentObject",
+      });
+    });
+  });
+
+  describe("#setConfig", () => {
+    it("updates the config settings", () => {
+      const testConfig = ({
+        test: "object",
+      } as unknown) as Config;
+
+      setConfig(testConfig);
+
+      expect(getConfig()).toMatchObject({ test: "object" });
+    });
+  });
+});

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -39,10 +39,11 @@ describe("config", () => {
       it("overrides the returned settings with any provided parameters", async () => {
         expect(
           await config.getConfig(({
-            test: "differentObject",
+            otherTest: "differentObject",
           } as unknown) as Config)
         ).toMatchObject({
-          test: "differentObject",
+          test: "object",
+          otherTest: "differentObject",
         });
       });
     });
@@ -76,10 +77,11 @@ describe("config", () => {
 
         expect(
           await config.getConfig(({
-            test: "differentObject",
+            otherTest: "differentObject",
           } as unknown) as Config)
         ).toMatchObject({
-          test: "differentObject",
+          test: "object",
+          otherTest: "differentObject",
         });
       });
     });

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -4,45 +4,45 @@ import { getConfig, setConfig, Config } from "./config";
 
 describe("config", () => {
   describe("#getConfig", () => {
-    it("returns the default settings when the config hasn't been set yet", () => {
-      expect(getConfig()).toMatchObject({
+    it("returns the default settings when the config hasn't been set yet", async () => {
+      expect(await getConfig()).toMatchObject({
         store: MemoryStore(),
         queue: MemoryQueue(),
       });
     });
 
-    it("fetches the current config settings", () => {
+    it("fetches the current config settings", async () => {
       const testConfig = ({
         test: "object",
       } as unknown) as Config;
 
-      setConfig(testConfig);
+      await setConfig(testConfig);
 
-      expect(getConfig()).toMatchObject({ test: "object" });
+      expect(await getConfig()).toMatchObject({ test: "object" });
     });
 
-    it("overrides the returned settings with any provided parameters", () => {
+    it("overrides the returned settings with any provided parameters", async () => {
       const testConfig = ({
         test: "object",
       } as unknown) as Config;
 
-      setConfig(testConfig);
+      await setConfig(testConfig);
 
-      expect(getConfig(({ test: "differentObject" } as unknown) as Config)).toMatchObject({
+      expect(await getConfig(({ test: "differentObject" } as unknown) as Config)).toMatchObject({
         test: "differentObject",
       });
     });
   });
 
   describe("#setConfig", () => {
-    it("updates the config settings", () => {
+    it("updates the config settings", async () => {
       const testConfig = ({
         test: "object",
       } as unknown) as Config;
 
-      setConfig(testConfig);
+      await setConfig(testConfig);
 
-      expect(getConfig()).toMatchObject({ test: "object" });
+      expect(await getConfig()).toMatchObject({ test: "object" });
     });
   });
 });

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1,35 +1,86 @@
-import MemoryStore from "../storage/memoryStorage";
-import MemoryQueue from "../batch/memoryQueue";
-import { getConfig, setConfig, Config } from "./config";
+import * as fs from "fs";
+import * as path from "path";
+
+import { Config } from "./config";
+
+// Require is necessary here to re-import the config module and reset local state
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+let config = require("./config");
+
+// module.export is necessary here because import is not supported in dynamic imports
+const TEST_CONFIG_FILE = `
+module.exports = { test: "object" };
+`;
 
 describe("config", () => {
   describe("#getConfig", () => {
-    it("returns the default settings when the config hasn't been set yet", async () => {
-      expect(await getConfig()).toMatchObject({
-        store: MemoryStore(),
-        queue: MemoryQueue(),
+    describe("with a config file", () => {
+      const configPath = path.resolve("./dsnp.config.js");
+
+      beforeAll(() => {
+        // Write test config to ./dsnp.config.js
+        fs.writeFileSync(configPath, TEST_CONFIG_FILE);
+      });
+
+      afterAll(() => {
+        // rm ./dsnp.config.js
+        fs.unlinkSync(configPath);
+
+        // Reimport config module to clear local state
+        jest.resetModules();
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        config = require("./config");
+      });
+
+      it("fetches the config settings from the file", async () => {
+        expect(await config.getConfig()).toMatchObject({ test: "object" });
+      });
+
+      it("overrides the returned settings with any provided parameters", async () => {
+        expect(
+          await config.getConfig(({
+            test: "differentObject",
+          } as unknown) as Config)
+        ).toMatchObject({
+          test: "differentObject",
+        });
       });
     });
 
-    it("fetches the current config settings", async () => {
-      const testConfig = ({
-        test: "object",
-      } as unknown) as Config;
+    describe("without a config file", () => {
+      it("returns the default settings when the config hasn't been set yet", async () => {
+        const results = await config.getConfig();
 
-      await setConfig(testConfig);
+        // We have to test keys here because #toMatchObject doesn't work with
+        // object instances
+        expect(results["store"]).toBeInstanceOf(Object);
+        expect(results["queue"]).toBeInstanceOf(Object);
+      });
 
-      expect(await getConfig()).toMatchObject({ test: "object" });
-    });
+      it("fetches the current config settings", async () => {
+        const testConfig = ({
+          test: "object",
+        } as unknown) as Config;
 
-    it("overrides the returned settings with any provided parameters", async () => {
-      const testConfig = ({
-        test: "object",
-      } as unknown) as Config;
+        await config.setConfig(testConfig);
 
-      await setConfig(testConfig);
+        expect(await config.getConfig()).toMatchObject({ test: "object" });
+      });
 
-      expect(await getConfig(({ test: "differentObject" } as unknown) as Config)).toMatchObject({
-        test: "differentObject",
+      it("overrides the returned settings with any provided parameters", async () => {
+        const testConfig = ({
+          test: "object",
+        } as unknown) as Config;
+
+        await config.setConfig(testConfig);
+
+        expect(
+          await config.getConfig(({
+            test: "differentObject",
+          } as unknown) as Config)
+        ).toMatchObject({
+          test: "differentObject",
+        });
       });
     });
   });
@@ -40,9 +91,9 @@ describe("config", () => {
         test: "object",
       } as unknown) as Config;
 
-      await setConfig(testConfig);
+      await config.setConfig(testConfig);
 
-      expect(await getConfig()).toMatchObject({ test: "object" });
+      expect(await config.getConfig()).toMatchObject({ test: "object" });
     });
   });
 });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,25 +1,25 @@
 import * as fs from "fs";
 import * as path from "path";
+import Web3 from "web3";
 
-// import Web3 from "web3";
-import MemoryStore from "../storage/memoryStorage";
 import MemoryQueue from "../batch/memoryQueue";
-
-import { StorageInterface } from "../storage/storage";
 import { QueueInterface } from "../batch/queue";
+import MemoryStore from "../storage/memoryStorage";
+import { StorageInterface } from "../storage/storage";
+import { EthereumAddress } from "../types/Strings";
 
 const CONFIG_FILE_PATH = "./dsnp.config.js";
 
 export interface Config {
-  // blockchain: ChainInterface;
-  store: StorageInterface;
+  accountAddress?: EthereumAddress;
+  provider?: Web3;
   queue: QueueInterface;
+  store: StorageInterface;
 }
 
-let config = {
-  // blockchain: new Web3.providers.HttpProvider(RPC_URL),
-  store: MemoryStore(),
+let config: Config = {
   queue: MemoryQueue(),
+  store: MemoryStore(),
 };
 
 let isConfigLoaded = false;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,10 +1,9 @@
 // import Web3 from "web3";
-// import MemoryStore from "../storage/memoryStorage";
-// import MemoryQueue from "../batch/memoryQueue";
+import MemoryStore from "../storage/memoryStorage";
+import MemoryQueue from "../batch/memoryQueue";
 
 import { StorageInterface } from "../storage/storage";
 import { QueueInterface } from "../batch/queue";
-import { NotImplementedError } from "../utilities/errors";
 
 export interface Config {
   // blockchain: ChainInterface;
@@ -12,11 +11,11 @@ export interface Config {
   queue: QueueInterface;
 }
 
-// let config = {
-//   blockchain: new Web3.providers.HttpProvider(RPC_URL),
-//   storage: new MemoryStore(),
-//   queue: new MemoryQueue(),
-// };
+let config = {
+  // blockchain: new Web3.providers.HttpProvider(RPC_URL),
+  store: MemoryStore(),
+  queue: MemoryQueue(),
+};
 
 /**
  * getConfig() fetches the current configuration settings and returns them. This
@@ -24,11 +23,9 @@ export interface Config {
  *
  * @returns The current configuration settings
  */
-export const getConfig = (_overrides?: Config): Config => {
-  throw NotImplementedError;
-
-  // if (!overrides) return config;
-  // return { ...overrides, ...config };
+export const getConfig = (overrides?: Config): Config => {
+  if (!overrides) return config;
+  return { ...config, ...overrides };
 };
 
 /**
@@ -37,8 +34,6 @@ export const getConfig = (_overrides?: Config): Config => {
  *
  * @params obj  The configuration settings to set with
  */
-export const setConfig = (_obj: Config): void => {
-  throw NotImplementedError;
-
-  // config = obj;
+export const setConfig = (obj: Config): void => {
+  config = obj;
 };

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -24,14 +24,12 @@ let config: Config = {
 
 let isConfigLoaded = false;
 const loadConfigFile = async (): Promise<void> => {
-  // If the config file has already been loaded, do nothing
   if (isConfigLoaded) return;
 
-  // If no config file exists, do nothing
   const filePath = path.resolve(CONFIG_FILE_PATH);
   if (!fs.existsSync(filePath) || fs.lstatSync(filePath).isDirectory()) return;
 
-  // Otherwise, load the config file from disk
+  // Load the config file from disk
   config = await import(filePath);
 
   // And set the flag to skip loading in the future

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -59,11 +59,11 @@ export const getConfig = async (overrides?: Config): Promise<Config> => {
  * setConfig() sets the current configuration with the given object. This method
  * is not yet implemented.
  *
- * @params obj  The configuration settings to set with
+ * @params newConfig The configuration settings to set with
  */
-export const setConfig = async (obj: Config): Promise<void> => {
+export const setConfig = async (newConfig: Config): Promise<void> => {
   // Set the config settings
-  config = obj;
+  config = newConfig;
 
   // Don't bother loading the config file in the future
   isConfigLoaded = true;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,9 +1,14 @@
+import * as fs from "fs";
+import * as path from "path";
+
 // import Web3 from "web3";
 import MemoryStore from "../storage/memoryStorage";
 import MemoryQueue from "../batch/memoryQueue";
 
 import { StorageInterface } from "../storage/storage";
 import { QueueInterface } from "../batch/queue";
+
+const CONFIG_FILE_PATH = "./dsnp.config.js";
 
 export interface Config {
   // blockchain: ChainInterface;
@@ -17,14 +22,36 @@ let config = {
   queue: MemoryQueue(),
 };
 
+let isConfigLoaded = false;
+const loadConfigFile = async (): Promise<void> => {
+  // If the config file has already been loaded, do nothing
+  if (isConfigLoaded) return;
+
+  // If no config file exists, do nothing
+  const filePath = path.resolve(CONFIG_FILE_PATH);
+  if (!fs.existsSync(filePath) || fs.lstatSync(filePath).isDirectory()) return;
+
+  // Otherwise, load the config file from disk
+  config = await import(filePath);
+
+  // And set the flag to skip loading in the future
+  isConfigLoaded = true;
+};
+
 /**
  * getConfig() fetches the current configuration settings and returns them. This
  * method is not yet implemented.
  *
  * @returns The current configuration settings
  */
-export const getConfig = (overrides?: Config): Config => {
+export const getConfig = async (overrides?: Config): Promise<Config> => {
+  // Load the config file from disk, if any
+  await loadConfigFile();
+
+  // Return the config, if there are no overrides to apply
   if (!overrides) return config;
+
+  // Otherwise, return the config with overrides
   return { ...config, ...overrides };
 };
 
@@ -34,6 +61,10 @@ export const getConfig = (overrides?: Config): Config => {
  *
  * @params obj  The configuration settings to set with
  */
-export const setConfig = (obj: Config): void => {
+export const setConfig = async (obj: Config): Promise<void> => {
+  // Set the config settings
   config = obj;
+
+  // Don't bother loading the config file in the future
+  isConfigLoaded = true;
 };

--- a/src/contracts/announcement.test.ts
+++ b/src/contracts/announcement.test.ts
@@ -4,6 +4,7 @@ import Web3 from "web3";
 import { keccak256 } from "js-sha3";
 
 import { batch } from "./announcement";
+import { setConfig, Config } from "../config/config";
 import { EthereumAddress } from "../types/Strings";
 
 const TESTING_PRIVATE_KEY = String(process.env.TESTING_PRIVATE_KEY);
@@ -18,9 +19,17 @@ describe("#batch", () => {
 
   it("successfully posts a batch to the chain", async () => {
     jest.setTimeout(12000);
+
     const testUri = "http://www.testconst.com";
     const hash = keccak256("test");
-    const receipt = await batch(web3, account.address as EthereumAddress, testUri, hash);
+
+    await setConfig({
+      accountAddress: account.address as EthereumAddress,
+      provider: web3,
+    } as Config);
+
+    const receipt = await batch(testUri, hash);
+
     expect(receipt).toEqual(
       expect.objectContaining({
         events: expect.objectContaining({

--- a/src/contracts/announcement.ts
+++ b/src/contracts/announcement.ts
@@ -4,7 +4,9 @@ import Web3 from "web3";
 import { Contract } from "web3-eth-contract";
 import { AbiItem } from "web3-utils";
 
+import { getConfig, Config } from "../config/config";
 import { HexString } from "../types/Strings";
+import { MissingAccountAddress, MissingProvider } from "../utilities/errors";
 import { hashPrefix } from "../utilities/hash";
 import { TransactionReceipt } from "web3-core/types";
 
@@ -69,18 +71,17 @@ const getGasLimit = async (contract: Contract, uri: string, hash: HexString, fro
  * batch() allows users call the batch smart contract and post the URI and hash
  * of a generated batch to the blockchain.
  *
- * @param provider  The web3 instance used for calling the smart contract
- * @param accountAddress   The address from which to post the batch
- * @param uri       The URI of the hosted batch to post
- * @param hash      A hash of the batch contents for use in verification
- * @returns         A [web3 contract receipt promise](https://web3js.readthedocs.io/en/v1.3.4/web3-eth-contract.html#id36)
+ * @param uri  The URI of the hosted batch to post
+ * @param hash A hash of the batch contents for use in verification
+ * @param opts Optional. Configuration overrides, such as from address, if any
+ * @returns    A [web3 contract receipt promise](https://web3js.readthedocs.io/en/v1.3.4/web3-eth-contract.html#id36)
  */
-export const batch = async (
-  provider: Web3,
-  accountAddress: string,
-  uri: string,
-  hash: HexString
-): Promise<TransactionReceipt> => {
+export const batch = async (uri: string, hash: HexString, opts?: Config): Promise<TransactionReceipt> => {
+  const { accountAddress, provider } = await getConfig(opts);
+
+  if (!accountAddress) throw MissingAccountAddress;
+  if (!provider) throw MissingProvider;
+
   const contract = await getContract(provider);
   const gasEstimate = await getGasLimit(contract, uri, hash, accountAddress);
 

--- a/src/utilities/errors.ts
+++ b/src/utilities/errors.ts
@@ -1,1 +1,3 @@
 export const NotImplementedError = new Error("This method is not yet implemented.");
+export const MissingAccountAddress = new Error("Account address is not set.");
+export const MissingProvider = new Error("Blockchain provider is not set.");

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "outDir": "dist/esm",
-    "module": "es6"
+    "module": "esnext"
   }
 }


### PR DESCRIPTION
Problem
=======
We need a way to provide configuration for the SDK, so users don't have to pass the same options to methods over and over again.
[#177682091](https://www.pivotaltracker.com/story/show/177682091)

Solution
========
Added a config module which accepts options by either a method call or configuration file.

Change summary:
---------------
* Added `#getConfig` method to config module with tests
* Added `#setConfig` method to config module with tests
* Added config file support with tests