### PR TITLE
Features/activity pub module 177859410

### DIFF
--- a/src/activityPub/activityPub.test.ts
+++ b/src/activityPub/activityPub.test.ts
@@ -1,83 +1,149 @@
-import { hash } from "./activityPub";
+import { create, hash, validate, ActivityPub } from "./activityPub";
 
-describe("#activityPubHash", () => {
-  it("returns a valid hash for an object", () => {
-    const sampleActivityPub = {
-      "@context": "https://www.w3.org/ns/activitystreams",
-      type: "Person",
-      id: "https://social.example/alyssa/",
-      name: "Alyssa P. Hacker",
-      preferredUsername: "alyssa",
-      summary: "Lisp enthusiast hailing from MIT",
-      inbox: "https://social.example/alyssa/inbox/",
-      outbox: "https://social.example/alyssa/outbox/",
-      followers: "https://social.example/alyssa/followers/",
-      following: "https://social.example/alyssa/following/",
-      liked: "https://social.example/alyssa/liked/",
-    };
+describe("activityPub", () => {
+  describe("#hash", () => {
+    it("returns a valid hash for an object", () => {
+      const sampleActivityPub = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        type: "Person",
+        id: "https://social.example/alyssa/",
+        name: "Alyssa P. Hacker",
+        preferredUsername: "alyssa",
+      };
 
-    expect(hash(sampleActivityPub)).toEqual("f828f3aa5d76779dc49efa69556ba89d0789cdd26ffe5d79be85da05c0afa842");
+      expect(hash(sampleActivityPub)).toEqual("2dd6859177d8068ac42cab7eda31da723012951ee38cba65a6880302a6afd91a");
+    });
+
+    it("returns the same hash for activityPubs in different orders", () => {
+      const sampleActivityPubA = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        type: "Person",
+        id: "https://social.example/alyssa/",
+        name: "Alyssa P. Hacker",
+        preferredUsername: "alyssa",
+      };
+      const sampleActivityPubB = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        type: "Person",
+        name: "Alyssa P. Hacker",
+        id: "https://social.example/alyssa/",
+        preferredUsername: "alyssa",
+      };
+
+      expect(hash(sampleActivityPubA)).toEqual(hash(sampleActivityPubB));
+    });
+
+    it("returns the different hashes for activityPubs with different content", () => {
+      const sampleActivityPubA = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        type: "Person",
+        id: "https://social.example/alyssa/",
+        name: "Alyssa P. Hacker",
+        preferredUsername: "alyssa",
+      };
+      const sampleActivityPubB = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        type: "Person",
+        id: "https://social.example/alyssa/",
+        name: "Alyssa P. Hacker",
+        preferredUsername: "hacker",
+      };
+
+      expect(hash(sampleActivityPubA)).not.toEqual(hash(sampleActivityPubB));
+    });
   });
 
-  it("returns the same hash for activityPubs in different orders", () => {
-    const sampleActivityPubA = {
-      "@context": "https://www.w3.org/ns/activitystreams",
-      type: "Person",
-      id: "https://social.example/alyssa/",
-      name: "Alyssa P. Hacker",
-      preferredUsername: "alyssa",
-      summary: "Lisp enthusiast hailing from MIT",
-      inbox: "https://social.example/alyssa/inbox/",
-      outbox: "https://social.example/alyssa/outbox/",
-      followers: "https://social.example/alyssa/followers/",
-      following: "https://social.example/alyssa/following/",
-      liked: "https://social.example/alyssa/liked/",
-    };
-    const sampleActivityPubB = {
-      "@context": "https://www.w3.org/ns/activitystreams",
-      type: "Person",
-      name: "Alyssa P. Hacker",
-      id: "https://social.example/alyssa/",
-      preferredUsername: "alyssa",
-      liked: "https://social.example/alyssa/liked/",
-      summary: "Lisp enthusiast hailing from MIT",
-      inbox: "https://social.example/alyssa/inbox/",
-      outbox: "https://social.example/alyssa/outbox/",
-      following: "https://social.example/alyssa/following/",
-      followers: "https://social.example/alyssa/followers/",
-    };
+  describe("#create", () => {
+    it("returns an activity pub object with the given parameters", () => {
+      const activityPub = create({
+        attachments: [
+          "http://placekitten.com/100/200",
+          "http://placekitten.com/300/400",
+          "http://placekitten.com/500/600",
+        ],
+        author: "0x0123456789ABCDEF",
+        body: "Look at these cats!",
+        title: "Some Cats",
+        url: "http://placekitten.com",
+        inReplyTo: "0x0123456789ABCDEF",
+      });
 
-    expect(hash(sampleActivityPubA)).toEqual(hash(sampleActivityPubB));
+      expect(activityPub).toMatchObject({
+        "@context": "https://www.w3.org/ns/activitystreams",
+        attachments: [
+          "http://placekitten.com/100/200",
+          "http://placekitten.com/300/400",
+          "http://placekitten.com/500/600",
+        ],
+        attributedTo: "0x0123456789ABCDEF",
+        content: "Look at these cats!",
+        inReplyTo: "0x0123456789ABCDEF",
+        name: "Some Cats",
+        type: "Note",
+        url: "http://placekitten.com",
+      });
+    });
+
+    it("returns an activity pub object with a valid published timestamp", () => {
+      const activityPub = create({
+        body: "Look at the time!",
+        title: "Time",
+      });
+
+      expect(activityPub["published"]).toMatch(/(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/);
+    });
   });
 
-  it("returns the different hashes for activityPubs with different content", () => {
-    const sampleActivityPubA = {
-      "@context": "https://www.w3.org/ns/activitystreams",
-      type: "Person",
-      id: "https://social.example/alyssa/",
-      name: "Alyssa P. Hacker",
-      preferredUsername: "alyssa",
-      summary: "Lisp enthusiast hailing from MIT",
-      inbox: "https://social.example/alyssa/inbox/",
-      outbox: "https://social.example/alyssa/outbox/",
-      followers: "https://social.example/alyssa/followers/",
-      following: "https://social.example/alyssa/following/",
-      liked: "https://social.example/alyssa/liked/",
-    };
-    const sampleActivityPubB = {
-      "@context": "https://www.w3.org/ns/activitystreams",
-      type: "Person",
-      id: "https://social.example/alyssa/",
-      name: "Alyssa P. Hacker",
-      preferredUsername: "hacker",
-      summary: "Lisp enthusiast hailing from MIT",
-      inbox: "https://social.example/alyssa/inbox/",
-      outbox: "https://social.example/alyssa/outbox/",
-      followers: "https://social.example/alyssa/followers/",
-      following: "https://social.example/alyssa/following/",
-      liked: "https://social.example/alyssa/liked/",
-    };
+  describe("#validate", () => {
+    it("return true for valid activity pub objects with valid published fields", () => {
+      const activityPub = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        type: "Note",
+        url: "http://placekitten.com",
+        published: "2015-02-10T15:04:55Z",
+      };
 
-    expect(hash(sampleActivityPubA)).not.toEqual(hash(sampleActivityPubB));
+      expect(validate(activityPub)).toBeTruthy();
+    });
+
+    it("return true for valid activity pub objects with no published field", () => {
+      const activityPub = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        type: "Note",
+        url: "http://placekitten.com",
+      };
+
+      expect(validate(activityPub)).toBeTruthy();
+    });
+
+    it("return false for activity pubs with incorrect published fields", () => {
+      const activityPub = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        type: "Note",
+        url: "http://placekitten.com",
+        published: "Yesterday",
+      };
+
+      expect(validate(activityPub)).toBeFalsy();
+    });
+
+    it("return false for activity pubs with incorrect contexts fields", () => {
+      const activityPub = {
+        "@context": "https://www.w3.org/ns/activitystream",
+        type: "Note",
+        url: "http://placekitten.com",
+      };
+
+      expect(validate(activityPub)).toBeFalsy();
+    });
+
+    it("return false for activity pubs with missing types", () => {
+      const activityPub = {
+        "@context": "https://www.w3.org/ns/activitystream",
+        url: "http://placekitten.com",
+      };
+
+      expect(validate(activityPub as ActivityPub)).toBeFalsy();
+    });
   });
 });

--- a/src/activityPub/activityPub.ts
+++ b/src/activityPub/activityPub.ts
@@ -2,7 +2,7 @@ import { keccak256 } from "js-sha3";
 import { HexString } from "../types/Strings";
 import { sortObject } from "../utilities/json";
 
-const ISO8601_REGEX = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})[+-](\d{2}):(\d{2})/;
+const ISO8601_REGEX = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})([+-](\d{2}):(\d{2}))?/;
 
 export interface ActivityPub {
   "@context": string;

--- a/src/activityPub/activityPub.ts
+++ b/src/activityPub/activityPub.ts
@@ -1,10 +1,19 @@
 import { keccak256 } from "js-sha3";
 import { HexString } from "../types/Strings";
-import { NotImplementedError } from "../utilities/errors";
 import { sortObject } from "../utilities/json";
+
+const ISO8601_REGEX = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})[+-](\d{2}):(\d{2})/;
 
 export interface ActivityPub {
   "@context": string;
+  type: string;
+  name?: string;
+  content?: string;
+  url?: string;
+  published?: string;
+  inReplyTo?: string;
+  attributedTo?: string;
+  attachments?: string;
 }
 
 /**
@@ -21,29 +30,63 @@ export const hash = (data: ActivityPub): HexString => {
   return keccak256(jsonString);
 };
 
-export interface ActivityPubCreateOpts {
-  title: string;
-  description: string;
+export interface BroadcastOptions {
+  attachments?: string[];
+  author?: string;
+  body?: string;
+  title?: string;
+  url?: string;
 }
 
+export interface ReplyOptions {
+  attachments?: string[];
+  author?: string;
+  body: string;
+  inReplyTo: string;
+}
+
+export interface ReactionOptions {
+  author?: string;
+  body: string;
+  inReplyTo: string;
+}
+
+export type ActivityPubOptions = BroadcastOptions | ReplyOptions | ReactionOptions;
+
 /**
- * create() provides a simple factory for generating activityPub objects. This
- * method is not yet implemented.
+ * create() provides a simple factory for generating activityPub notes.
  *
- * @param   opts  Options for the created activity pub object
- * @returns       An activity pub object
+ * @param   options Options for the activity pub object to create
+ * @returns         An activity pub object
  */
-export const create = (_opts: ActivityPubCreateOpts): ActivityPub => {
-  throw NotImplementedError;
+export const create = (options: ActivityPubOptions): ActivityPub => {
+  const activityPub: Record<string, unknown> = {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    type: "Note",
+    published: new Date().toISOString(),
+  };
+
+  if ((options as BroadcastOptions).title) activityPub["name"] = (options as BroadcastOptions).title;
+  if (options.body) activityPub["content"] = (options as BroadcastOptions).body;
+  if (options.author) activityPub["attributedTo"] = options.author;
+  if ((options as ReplyOptions).inReplyTo) activityPub["inReplyTo"] = (options as ReplyOptions).inReplyTo;
+  if ((options as BroadcastOptions).url) activityPub["url"] = (options as BroadcastOptions).url;
+  if ((options as BroadcastOptions).attachments) activityPub["attachments"] = (options as BroadcastOptions).attachments;
+
+  return (activityPub as unknown) as ActivityPub;
 };
 
 /**
  * validate() returns true if the object provided is a valid activityPub.
- * Otherwise, it returns false. This method is not yet implemented.
+ * Otherwise, it returns false.
  *
- * @param   obj  An object to be validated against the activity pub standard
- * @returns      True or false depending on whether the given object is a valid
+ * @param   activityPub  An object to be validated against the activity pub standard
+ * @returns              True or false depending on whether the given object is a valid
  */
-export const validate = (_obj: unknown): boolean => {
-  throw NotImplementedError;
+export const validate = (activityPub: ActivityPub): boolean => {
+  if (activityPub["@context"] !== "https://www.w3.org/ns/activitystreams") return false;
+  if (!activityPub.type || typeof activityPub.type !== "string") return false;
+  if (activityPub.published && !activityPub.published.match(ISO8601_REGEX)) return false;
+
+  return true;
 };

--- a/src/social/content.ts
+++ b/src/social/content.ts
@@ -1,7 +1,7 @@
 // import * as activityPub from "../activityPub/activityPub";
 // import * as config from "../config/config";
 // import * as storage from "../storage/storage";
-import { ActivityPubCreateOpts } from "../activityPub/activityPub";
+import { BroadcastOptions, ReactionOptions, ReplyOptions } from "../activityPub/activityPub";
 import { Config } from "../config/config";
 import { NotImplementedError } from "../utilities/errors";
 
@@ -9,11 +9,11 @@ import { NotImplementedError } from "../utilities/errors";
  * broadcast() creates a broadcast DSNP event and enqueues it for the next
  * batch. This method is not yet implemented.
  *
- * @param activityPubOpts  Any options for the activity pub event to create
- * @param opts             Optional. Configuration overrides, such as from address, if any
+ * @param content The content for the note to broadcast
+ * @param opts    Optional. Configuration overrides, such as from address, if any
  *
  */
-export const broadcast = async (_activityPubOpts: ActivityPubCreateOpts, _opts?: Config): Promise<void> => {
+export const broadcast = async (_content: BroadcastOptions, _opts?: Config): Promise<void> => {
   throw NotImplementedError;
 
   // const config = config.getConfig(opts);
@@ -30,10 +30,10 @@ export const broadcast = async (_activityPubOpts: ActivityPubCreateOpts, _opts?:
  * reply() creates a reply activity pub event and enqueues it for the next
  * batch. This method is not yet implemented.
  *
- * @param activityPubOpts  Any options for the activity pub event to create
- * @param opts             Optional. Configuration overrides, such as from address, if any
+ * @param content The content for the reply to broadcast
+ * @param opts    Optional. Configuration overrides, such as from address, if any
  */
-export const reply = async (_activityPubOpts: ActivityPubCreateOpts, _opts: Config): Promise<void> => {
+export const reply = async (_content: ReplyOptions, _opts: Config): Promise<void> => {
   throw NotImplementedError;
 
   // const config = config.getConfig(opts);
@@ -51,10 +51,10 @@ export const reply = async (_activityPubOpts: ActivityPubCreateOpts, _opts: Conf
  * react() creates a reaction activity pub event and enqueues it for the next
  * batch. This method is not yet implemented.
  *
- * @param activityPubOpts  Any options for the activity pub event to create
- * @param opts             Optional. Configuration overrides, such as from address, if any
+ * @param content The content for the reaction to broadcast
+ * @param opts    Optional. Configuration overrides, such as from address, if any
  */
-export const react = async (_activityPubOpts: ActivityPubCreateOpts, _opts: Config): Promise<void> => {
+export const react = async (_content: ReactionOptions, _opts: Config): Promise<void> => {
   throw NotImplementedError;
 
   // const config = config.getConfig(opts);


### PR DESCRIPTION
Problem
=======
We need a way to work with activity pub objects for use in the high-level porcelain methods for publishing content.
[#177859410](https://www.pivotaltracker.com/story/show/177859410)

Solution
========
Add `create` and `validate` methods to the activity pub module

Change summary:
---------------
* Added `create()` method
* Added `validate()` method
* Added associated tests