### PR TITLE
Bugs/config partial type mismatch

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -34,6 +34,11 @@ export interface Config {
   };
 }
 
+/**
+ * ConfigOpts represents override options to be passed when fetching the config
+ */
+export type ConfigOpts = Partial<Config>;
+
 let config: Config = {
   contracts: {},
   queue: new MemoryQueue(),
@@ -44,7 +49,7 @@ let config: Config = {
  *
  * @returns The current configuration settings
  */
-export const getConfig = (overrides?: Partial<Config>): Config => {
+export const getConfig = (overrides?: ConfigOpts): Config => {
   if (!overrides) return config;
 
   return {
@@ -59,7 +64,7 @@ export const getConfig = (overrides?: Partial<Config>): Config => {
  *
  * @params newConfig The configuration settings to set with
  */
-export const setConfig = (newConfig: Partial<Config>): void => {
+export const setConfig = (newConfig: ConfigOpts): void => {
   config = {
     // Defaults
     queue: new MemoryQueue(),

--- a/src/messages/messages.ts
+++ b/src/messages/messages.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 
-import { getConfig, Config } from "../config/config";
+import { getConfig, ConfigOpts } from "../config/config";
 import { HexString } from "../types/Strings";
 import { MissingSigner } from "../utilities/errors";
 import { sortObject } from "../utilities/json";
@@ -124,7 +124,7 @@ const serialize = (message: DSNPMessage): string => {
  * @param opts    Optional. Configuration overrides, such as from address, if any
  * @returns       The message signature in hex
  */
-export const sign = async (message: DSNPMessage, opts?: Config): Promise<HexString> => {
+export const sign = async (message: DSNPMessage, opts?: ConfigOpts): Promise<HexString> => {
   const { signer } = await getConfig(opts);
   if (!signer) throw MissingSigner;
   return signer.signMessage(serialize(message));

--- a/src/queue/queue.ts
+++ b/src/queue/queue.ts
@@ -1,4 +1,4 @@
-import { getConfig, Config } from "../config/config";
+import { getConfig, ConfigOpts } from "../config/config";
 import { DSNPMessage, DSNPType } from "../messages/messages";
 
 /**
@@ -27,7 +27,7 @@ export interface QueueInterface {
  * @param opts    Optional. Configuration overrides, such as from address, if any
  * @returns       A Queue ID for the queued message
  */
-export const enqueue = async (message: DSNPMessage, opts?: Config): Promise<QueueId> => {
+export const enqueue = async (message: DSNPMessage, opts?: ConfigOpts): Promise<QueueId> => {
   const config = getConfig(opts);
   return await config.queue.enqueue(message);
 };
@@ -40,7 +40,7 @@ export const enqueue = async (message: DSNPMessage, opts?: Config): Promise<Queu
  * @param opts Optional. Configuration overrides, such as from address, if any
  * @returns    The DSNP message removed from the queue
  */
-export const remove = async (id: QueueId, opts?: Config): Promise<DSNPMessage> => {
+export const remove = async (id: QueueId, opts?: ConfigOpts): Promise<DSNPMessage> => {
   const config = getConfig(opts);
   return await config.queue.remove(id);
 };
@@ -55,7 +55,7 @@ export const remove = async (id: QueueId, opts?: Config): Promise<DSNPMessage> =
  * @param opts  Optional. Configuration overrides, such as from address, if any
  * @returns     An array of DSNP messages removed from the queue
  */
-export const dequeueBatch = async (dsnpType: DSNPType, count: number, opts?: Config): Promise<DSNPMessage[]> => {
+export const dequeueBatch = async (dsnpType: DSNPType, count: number, opts?: ConfigOpts): Promise<DSNPMessage[]> => {
   const config = getConfig(opts);
   const results: DSNPMessage[] = [];
 

--- a/src/social/content.ts
+++ b/src/social/content.ts
@@ -2,7 +2,7 @@
 // import * as config from "../config/config";
 // import * as storage from "../storage/storage";
 import { BroadcastOptions, ReactionOptions, ReplyOptions } from "../activityPub/activityPub";
-import { Config } from "../config/config";
+import { ConfigOpts } from "../config/config";
 import { NotImplementedError } from "../utilities/errors";
 
 /**
@@ -13,7 +13,7 @@ import { NotImplementedError } from "../utilities/errors";
  * @param opts    Optional. Configuration overrides, such as from address, if any
  *
  */
-export const broadcast = async (_content: BroadcastOptions, _opts?: Config): Promise<void> => {
+export const broadcast = async (_content: BroadcastOptions, _opts?: ConfigOpts): Promise<void> => {
   throw NotImplementedError;
 
   // const config = config.getConfig(opts);
@@ -33,7 +33,7 @@ export const broadcast = async (_content: BroadcastOptions, _opts?: Config): Pro
  * @param content The content for the reply to broadcast
  * @param opts    Optional. Configuration overrides, such as from address, if any
  */
-export const reply = async (_content: ReplyOptions, _opts: Config): Promise<void> => {
+export const reply = async (_content: ReplyOptions, _opts?: ConfigOpts): Promise<void> => {
   throw NotImplementedError;
 
   // const config = config.getConfig(opts);
@@ -54,7 +54,7 @@ export const reply = async (_content: ReplyOptions, _opts: Config): Promise<void
  * @param content The content for the reaction to broadcast
  * @param opts    Optional. Configuration overrides, such as from address, if any
  */
-export const react = async (_content: ReactionOptions, _opts: Config): Promise<void> => {
+export const react = async (_content: ReactionOptions, _opts?: ConfigOpts): Promise<void> => {
   throw NotImplementedError;
 
   // const config = config.getConfig(opts);

--- a/src/social/handles.ts
+++ b/src/social/handles.ts
@@ -1,4 +1,4 @@
-import { Config } from "../config/config";
+import { ConfigOpts } from "../config/config";
 import { HexString } from "../types/Strings";
 import { NotImplementedError } from "../utilities/errors";
 import { registry } from "../contracts";
@@ -24,7 +24,7 @@ export type Handle = string;
  * @param id  The Handle of the user for which to fetch profile data
  * @param opts Optional. Configuration overrides, such as from address, if any
  */
-export const authenticateHandle = async (_id: Handle, _opts?: Config): Promise<void> => {
+export const authenticateHandle = async (_id: Handle, _opts?: ConfigOpts): Promise<void> => {
   throw NotImplementedError;
 };
 
@@ -36,7 +36,7 @@ export const authenticateHandle = async (_id: Handle, _opts?: Config): Promise<v
  * @param opts Optional. Configuration overrides, such as from address, if any
  * @returns    The User object associated with the given Handle
  */
-export const getUser = async (_id: Handle, _opts?: Config): Promise<User> => {
+export const getUser = async (_id: Handle, _opts?: ConfigOpts): Promise<User> => {
   throw NotImplementedError;
 };
 
@@ -50,7 +50,7 @@ export const getUser = async (_id: Handle, _opts?: Config): Promise<User> => {
  * @param opts Optional. Configuration overrides, such as from address, if any
  * @returns    The User object associated with the given Handle
  */
-export const updateUser = async (_id: Handle, _user: User, _opts?: Config): Promise<User> => {
+export const updateUser = async (_id: Handle, _user: User, _opts?: ConfigOpts): Promise<User> => {
   throw NotImplementedError;
 };
 
@@ -62,7 +62,7 @@ export const updateUser = async (_id: Handle, _user: User, _opts?: Config): Prom
  * @param opts   Optional. Configuration overrides, such as from address, if any
  * @returns      The DSNP address associated with the given handle
  */
-export const handleToAddress = async (_handle: Handle, _opts?: Config): Promise<HexString> => {
+export const handleToAddress = async (_handle: Handle, _opts?: ConfigOpts): Promise<HexString> => {
   throw NotImplementedError;
 };
 
@@ -74,7 +74,7 @@ export const handleToAddress = async (_handle: Handle, _opts?: Config): Promise<
  * @param opts    Optional. Configuration overrides, such as from address, if any
  * @returns       An array of DSNP handles associated with the address
  */
-export const addressToHandles = async (_address: HexString, _opts?: Config): Promise<Handle[]> => {
+export const addressToHandles = async (_address: HexString, _opts?: ConfigOpts): Promise<Handle[]> => {
   throw NotImplementedError;
 };
 

--- a/src/social/network.ts
+++ b/src/social/network.ts
@@ -1,5 +1,5 @@
 import { Handle } from "./handles";
-import { Config } from "../config/config";
+import { ConfigOpts } from "../config/config";
 import { NotImplementedError } from "../utilities/errors";
 
 /**
@@ -9,7 +9,7 @@ import { NotImplementedError } from "../utilities/errors";
  * @param handle  The handle of the user to follow
  * @param opts    Optional. Configuration overrides, such as from address, if any
  */
-export const follow = async (_handle: Handle, _opts?: Config): Promise<void> => {
+export const follow = async (_handle: Handle, _opts?: ConfigOpts): Promise<void> => {
   throw NotImplementedError;
 };
 
@@ -20,7 +20,7 @@ export const follow = async (_handle: Handle, _opts?: Config): Promise<void> => 
  * @param handle  The handle of the user to unfollow
  * @param opts    Optional. Configuration overrides, such as from address, if any
  */
-export const unfollow = async (_handle: Handle, _opts?: Config): Promise<void> => {
+export const unfollow = async (_handle: Handle, _opts?: ConfigOpts): Promise<void> => {
   throw NotImplementedError;
 };
 
@@ -34,7 +34,7 @@ export const unfollow = async (_handle: Handle, _opts?: Config): Promise<void> =
  * @param opts     Optional. Configuration overrides, such as from address, if any
  * @returns        A boolean representing whether or not the follower is following the followee
  */
-export const isFollowing = async (_follower: Handle, _followee?: Handle, _opts?: Config): Promise<boolean> => {
+export const isFollowing = async (_follower: Handle, _followee?: Handle, _opts?: ConfigOpts): Promise<boolean> => {
   throw NotImplementedError;
 };
 
@@ -47,7 +47,7 @@ export const isFollowing = async (_follower: Handle, _followee?: Handle, _opts?:
  * @param opts     Optional. Configuration overrides, such as from address, if any
  * @returns        An array of all users following the followee
  */
-export const getFollowers = async (_followee?: Handle, _opts?: Config): Promise<Handle[]> => {
+export const getFollowers = async (_followee?: Handle, _opts?: ConfigOpts): Promise<Handle[]> => {
   throw NotImplementedError;
 };
 
@@ -60,6 +60,6 @@ export const getFollowers = async (_followee?: Handle, _opts?: Config): Promise<
  * @param opts     Optional. Configuration overrides, such as from address, if any
  * @returns        An array of all users followed by the follower user
  */
-export const getFollowees = (_follower?: Handle, _opts?: Config): Promise<Handle[]> => {
+export const getFollowees = (_follower?: Handle, _opts?: ConfigOpts): Promise<Handle[]> => {
   throw NotImplementedError;
 };


### PR DESCRIPTION
Problem
=======
All our methods with an `opts: Config` parameter require a complete `Config` object rather than a partial.

No task for this.

Solution
========
Create a `ConfigOpts` type defined as `Partial<Config>` and update all instance of `opts` to be `ConfigOpts`.