### PR TITLE
Validate messages, signature + permission #178267391

### DIFF
--- a/src/core/contracts/registry.test.ts
+++ b/src/core/contracts/registry.test.ts
@@ -221,6 +221,13 @@ describe("registry", () => {
       expect(regs[1].handle).toEqual(handle + "new");
     });
   });
+
+  describe("validateMessage", () => {
+    it("throws if not registered");
+    it("throws if can't get block height");
+    it("returns true if the signer is authorized to do the thing");
+    it("returns false if the signer is not authorized to do the thing");
+  });
 });
 
 const getIdFromRegisterTransaction = async (transaction: ContractTransaction) => {

--- a/src/core/contracts/registry.test.ts
+++ b/src/core/contracts/registry.test.ts
@@ -268,8 +268,7 @@ describe("registry", () => {
 
     it("returns false if the signer is not authorized for the given permissions", async () => {
       const regSigner: RegistrationWithSigner = await newRegistrationForAccountIndex(19, "Handel");
-      const res = await validateMessage(sig, msg, regSigner.dsnpId.toString(), permDenied);
-      expect(res).toBeFalsy();
+      await expect(validateMessage(sig, msg, regSigner.dsnpId.toString(), permDenied)).toBeFalsy();
     });
 
     it("accepts a block number", async () => {

--- a/src/core/contracts/registry.test.ts
+++ b/src/core/contracts/registry.test.ts
@@ -268,7 +268,7 @@ describe("registry", () => {
     });
 
     it("returns false if the signer is not authorized for the given permissions", async () => {
-      const regSigner: RegistrationWithSigner = await newRegistrationForAccountIndex(19, "Handel");
+      const regSigner: RegistrationWithSigner = await newRegistrationForAccountIndex(2, "Handel");
       const res = await validateMessage(sig, msg, regSigner.dsnpId.toString(), permDenied);
       expect(res).toBeFalsy();
     });

--- a/src/core/contracts/registry.test.ts
+++ b/src/core/contracts/registry.test.ts
@@ -1,4 +1,4 @@
-import { BigNumber, ContractTransaction, Signer } from "ethers";
+import { BigNumber, Signer } from "ethers";
 import { JsonRpcProvider } from "@ethersproject/providers";
 import { revertHardhat, snapshotHardhat, snapshotSetup } from "../../test/hardhatRPC";
 import {
@@ -9,11 +9,11 @@ import {
   resolveRegistration,
   validateMessage,
 } from "./registry";
-import { Identity__factory, Registry__factory } from "../../types/typechain";
-import { setupConfig, getSignerFromPrivateKey } from "../../test/sdkTestConfig";
+import { Identity__factory } from "../../types/typechain";
+import { setupConfig } from "../../test/sdkTestConfig";
 import { Permission } from "./identity";
-import { DSNPMessage, sign } from "../messages/messages";
-import { generateBroadcast} from "../../test/generators/dsnpGenerators";
+import { DSNPMessage, sign } from "../messages";
+import { generateBroadcast } from "../../test/generators/dsnpGenerators";
 import {
   getIdFromRegisterTransaction,
   newRegistrationForAccountIndex,

--- a/src/core/contracts/registry.ts
+++ b/src/core/contracts/registry.ts
@@ -8,6 +8,7 @@ import { Registry__factory } from "../../types/typechain";
 import { Permission } from "./identity";
 import { resolveId} from "../../handles";
 import { isAuthorizedTo } from "./identity";
+import { DSNPMessage, serialize } from "../messages/messages";
 
 const CONTRACT_NAME = "Registry";
 
@@ -108,7 +109,7 @@ export const getDSNPRegistryUpdateEvents = async (
 
 export const validateMessage = async (
   signature: HexString,
-  message: string,
+  message: DSNPMessage,
   dsnpId: HexString,
   permission: Permission
 ): Promise<boolean> => {
@@ -121,7 +122,7 @@ export const validateMessage = async (
   const bh = (await provider?.getBlock("latest"))?.number;
   if (!bh) throw MissingProvider;
 
-  const signerAddr = ethers.utils.verifyMessage(message, signature);
+  const signerAddr = ethers.utils.verifyMessage(serialize(message), signature);
   return isAuthorizedTo(signerAddr, reg.contractAddr, permission, bh);
 };
 

--- a/src/core/contracts/registry.ts
+++ b/src/core/contracts/registry.ts
@@ -6,9 +6,9 @@ import { BigNumber, ContractTransaction } from "ethers";
 import { MissingContract, MissingProvider, MissingSigner } from "../utilities";
 import { Registry__factory } from "../../types/typechain";
 import { Permission } from "./identity";
-import { resolveId} from "../../handles";
+import { resolveId } from "../../handles";
 import { isAuthorizedTo } from "./identity";
-import { DSNPMessage, serialize } from "../messages/messages";
+import { DSNPMessage, serialize } from "../messages";
 
 const CONTRACT_NAME = "Registry";
 

--- a/src/core/messages/messages.ts
+++ b/src/core/messages/messages.ts
@@ -23,9 +23,6 @@ export interface DSNPMessage {
   dsnpType: DSNPType;
 }
 
-/**
- * BroadcastMessage: a DSNP message of type Broadcast
- */
 export interface BroadcastMessage extends DSNPMessage {
   dsnpType: DSNPType.Broadcast;
   contentHash: string;
@@ -104,7 +101,7 @@ export const createReactionMessage = (fromId: string, emoji: string, inReplyTo: 
   inReplyTo,
 });
 
-const serialize = (message: DSNPMessage): string => {
+export const serialize = (message: DSNPMessage): string => {
   const sortedMessage = sortObject((message as unknown) as Record<string, unknown>);
   let serialization = "";
 

--- a/src/core/messages/messages.ts
+++ b/src/core/messages/messages.ts
@@ -23,6 +23,9 @@ export interface DSNPMessage {
   dsnpType: DSNPType;
 }
 
+/**
+ * BroadcastMessage: a DSNP message of type Broadcast
+ */
 export interface BroadcastMessage extends DSNPMessage {
   dsnpType: DSNPType.Broadcast;
   contentHash: string;

--- a/src/test/sdkTestConfig.ts
+++ b/src/test/sdkTestConfig.ts
@@ -1,6 +1,6 @@
 //eslint-disable-next-line
 require("dotenv").config();
-import { setConfig } from "../config";
+import { getConfig, setConfig } from "../config";
 import { ethers } from "ethers";
 
 type SdkTestConfig = { provider: ethers.providers.JsonRpcProvider; signer: ethers.Signer };
@@ -18,4 +18,14 @@ export const setupConfig = (): SdkTestConfig => {
     signer,
     provider,
   };
+};
+
+/**
+ * Use this function to set up a new signer other than what is in the config.
+ * @param privateKey
+ */
+export const getSignerFromPrivateKey = (privateKey: string): ethers.Signer => {
+  const { provider } = getConfig();
+  if (!provider) throw new Error("no provider configured");
+  return new ethers.Wallet(privateKey, provider);
 };

--- a/src/test/sdkTestConfig.ts
+++ b/src/test/sdkTestConfig.ts
@@ -1,6 +1,6 @@
 //eslint-disable-next-line
 require("dotenv").config();
-import { getConfig, setConfig } from "../config";
+import { setConfig } from "../config";
 import { ethers } from "ethers";
 
 type SdkTestConfig = { provider: ethers.providers.JsonRpcProvider; signer: ethers.Signer };
@@ -18,14 +18,4 @@ export const setupConfig = (): SdkTestConfig => {
     signer,
     provider,
   };
-};
-
-/**
- * Use this function to set up a new signer other than what is in the config.
- * @param privateKey
- */
-export const getSignerFromPrivateKey = (privateKey: string): ethers.Signer => {
-  const { provider } = getConfig();
-  if (!provider) throw new Error("no provider configured");
-  return new ethers.Wallet(privateKey, provider);
 };

--- a/src/test/testAccounts.ts
+++ b/src/test/testAccounts.ts
@@ -47,7 +47,7 @@ export const newRegistrationForAccountIndex = async (
   const identityContract = await new Identity__factory(signer).deploy(newSignerAddr);
   await identityContract.deployed();
   const contractAddr = identityContract.address;
-  const tx2 = await register(contractAddr, "Handel");
+  const tx2 = await register(contractAddr, handle);
   const dsnpId = await getIdFromRegisterTransaction(tx2);
   return { contractAddr, dsnpId, handle, signer };
 };

--- a/src/test/testAccounts.ts
+++ b/src/test/testAccounts.ts
@@ -7,52 +7,7 @@ export interface RegistrationWithSigner extends Registration {
   signer: ethers.Signer;
 }
 
-/**
- * Use this function to set up a new signer other than what is in the config.
- * @param accountIndex the index in the TestAccounts to get the signer for.
- * @return the ethers.Signer associated with the test account
- */
-export const getSignerForAccount = (accountIndex: number): ethers.Signer => {
-  if (accountIndex >= TestAccounts.length) throw new Error(`there are only ${TestAccounts.length} accounts.`);
-  const { provider } = getConfig();
-  if (!provider) throw new Error("no provider configured");
-  return new ethers.Wallet(TestAccounts[accountIndex].privateKey, provider);
-};
-
-/**
- * Parses a DSNP Id in a contract transaction log event.
- * @param transaction
- * @returns the DSNP Id
- */
-export const getIdFromRegisterTransaction = async (transaction: ContractTransaction): Promise<any> => {
-  const receipt = await transaction.wait(1);
-  const reg = Registry__factory.createInterface();
-  const event = reg.parseLog(receipt.logs[0]);
-  return event.args[0];
-};
-
-/**
- * Creates a new DSNP Identity Proxy contract using the specified test account, and registers the
- * provided handle. Callers must keep track of what accounts have already been used.
- * @param acctIdx the index in TestAccounts to use.
- * @param handle the handle to register
- * @return a RegistrationWithSigner object
- */
-export const newRegistrationForAccountIndex = async (
-  acctIdx: number,
-  handle: string
-): Promise<RegistrationWithSigner> => {
-  const signer = getSignerForAccount(acctIdx);
-  const newSignerAddr = await signer.getAddress();
-  const identityContract = await new Identity__factory(signer).deploy(newSignerAddr);
-  await identityContract.deployed();
-  const contractAddr = identityContract.address;
-  const tx2 = await register(contractAddr, handle);
-  const dsnpId = await getIdFromRegisterTransaction(tx2);
-  return { contractAddr, dsnpId, handle, signer };
-};
-
-const TestAccounts = [
+const TESTACCOUNTS = [
   {
     account: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
     privateKey: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
@@ -157,3 +112,48 @@ const TestAccounts = [
     privateKey: "0xdf57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e",
   },
 ];
+
+/**
+ * Use this function to set up a new signer other than what is in the config.
+ * @param accountIndex the index in the TESTACCOUNTS to get the signer for.
+ * @return the ethers.Signer associated with the test account
+ */
+export const getSignerForAccount = (accountIndex: number): ethers.Signer => {
+  if (accountIndex >= TESTACCOUNTS.length) throw new Error(`there are only ${TESTACCOUNTS.length} accounts.`);
+  const { provider } = getConfig();
+  if (!provider) throw new Error("no provider configured");
+  return new ethers.Wallet(TESTACCOUNTS[accountIndex].privateKey, provider);
+};
+
+/**
+ * Parses a DSNP Id in a contract transaction log event.
+ * @param transaction
+ * @returns the DSNP Id
+ */
+export const getIdFromRegisterTransaction = async (transaction: ContractTransaction): Promise<any> => {
+  const receipt = await transaction.wait(1);
+  const reg = Registry__factory.createInterface();
+  const event = reg.parseLog(receipt.logs[0]);
+  return event.args[0];
+};
+
+/**
+ * Creates a new DSNP Identity Proxy contract using the specified test account, and registers the
+ * provided handle. Callers must keep track of what accounts have already been used.
+ * @param acctIdx the index in TESTACCOUNTS to use.
+ * @param handle the handle to register
+ * @return a RegistrationWithSigner object
+ */
+export const newRegistrationForAccountIndex = async (
+  acctIdx: number,
+  handle: string
+): Promise<RegistrationWithSigner> => {
+  const signer = getSignerForAccount(acctIdx);
+  const newSignerAddr = await signer.getAddress();
+  const identityContract = await new Identity__factory(signer).deploy(newSignerAddr);
+  await identityContract.deployed();
+  const contractAddr = identityContract.address;
+  const tx2 = await register(contractAddr, handle);
+  const dsnpId = await getIdFromRegisterTransaction(tx2);
+  return { contractAddr, dsnpId, handle, signer };
+};

--- a/src/test/testAccounts.ts
+++ b/src/test/testAccounts.ts
@@ -1,0 +1,159 @@
+import { ContractTransaction, ethers } from "ethers";
+import { getConfig } from "../config/config";
+import { register, Registration } from "../contracts/registry";
+import { Identity__factory, Registry__factory } from "../types/typechain";
+
+export interface RegistrationWithSigner extends Registration {
+  signer: ethers.Signer;
+}
+
+/**
+ * Use this function to set up a new signer other than what is in the config.
+ * @param accountIndex the index in the TestAccounts to get the signer for.
+ * @return the ethers.Signer associated with the test account
+ */
+export const getSignerForAccount = (accountIndex: number): ethers.Signer => {
+  if (accountIndex >= TestAccounts.length) throw new Error(`there are only ${TestAccounts.length} accounts.`);
+  const { provider } = getConfig();
+  if (!provider) throw new Error("no provider configured");
+  return new ethers.Wallet(TestAccounts[accountIndex].privateKey, provider);
+};
+
+/**
+ * Parses a DSNP Id in a contract transaction log event.
+ * @param transaction
+ * @returns the DSNP Id
+ */
+export const getIdFromRegisterTransaction = async (transaction: ContractTransaction): Promise<any> => {
+  const receipt = await transaction.wait(1);
+  const reg = Registry__factory.createInterface();
+  const event = reg.parseLog(receipt.logs[0]);
+  return event.args[0];
+};
+
+/**
+ * Creates a new DSNP Identity Proxy contract using the specified test account, and registers the
+ * provided handle. Callers must keep track of what accounts have already been used.
+ * @param acctIdx the index in TestAccounts to use.
+ * @param handle the handle to register
+ * @return a RegistrationWithSigner object
+ */
+export const newRegistrationForAccountIndex = async (
+  acctIdx: number,
+  handle: string
+): Promise<RegistrationWithSigner> => {
+  const signer = getSignerForAccount(acctIdx);
+  const newSignerAddr = await signer.getAddress();
+  const identityContract = await new Identity__factory(signer).deploy(newSignerAddr);
+  await identityContract.deployed();
+  const contractAddr = identityContract.address;
+  const tx2 = await register(contractAddr, "Handel");
+  const dsnpId = await getIdFromRegisterTransaction(tx2);
+  return { contractAddr, dsnpId, handle, signer };
+};
+
+const TestAccounts = [
+  {
+    account: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+    privateKey: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+  },
+
+  {
+    account: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+    privateKey: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
+  },
+
+  {
+    account: "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc",
+    privateKey: "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a",
+  },
+
+  {
+    account: "0x90f79bf6eb2c4f870365e785982e1f101e93b906",
+    privateKey: "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6",
+  },
+
+  {
+    account: "0x15d34aaf54267db7d7c367839aaf71a00a2c6a65",
+    privateKey: "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a",
+  },
+
+  // 5
+  {
+    account: "0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc",
+    privateKey: "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba",
+  },
+
+  {
+    account: "0x976ea74026e726554db657fa54763abd0c3a0aa9",
+    privateKey: "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e",
+  },
+
+  {
+    account: "0x14dc79964da2c08b23698b3d3cc7ca32193d9955",
+    privateKey: "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356",
+  },
+
+  {
+    account: "0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f",
+    privateKey: "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97",
+  },
+
+  {
+    account: "0xa0ee7a142d267c1f36714e4a8f75612f20a79720",
+    privateKey: "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6",
+  },
+
+  // 10
+  {
+    account: "0xbcd4042de499d14e55001ccbb24a551f3b954096",
+    privateKey: "0xf214f2b2cd398c806f84e317254e0f0b801d0643303237d97a22a48e01628897",
+  },
+
+  {
+    account: "0x71be63f3384f5fb98995898a86b02fb2426c5788",
+    privateKey: "0x701b615bbdfb9de65240bc28bd21bbc0d996645a3dd57e7b12bc2bdf6f192c82",
+  },
+
+  {
+    account: "0xfabb0ac9d68b0b445fb7357272ff202c5651694a",
+    privateKey: "0xa267530f49f8280200edf313ee7af6b827f2a8bce2897751d06a843f644967b1",
+  },
+
+  {
+    account: "0x1cbd3b2770909d4e10f157cabc84c7264073c9ec",
+    privateKey: "0x47c99abed3324a2707c28affff1267e45918ec8c3f20b8aa892e8b065d2942dd",
+  },
+
+  {
+    account: "0xdf3e18d64bc6a983f673ab319ccae4f1a57c7097",
+    privateKey: "0xc526ee95bf44d8fc405a158bb884d9d1238d99f0612e9f33d006bb0789009aaa",
+  },
+
+  // 15
+  {
+    account: "0xcd3b766ccdd6ae721141f452c550ca635964ce71",
+    privateKey: "0x8166f546bab6da521a8369cab06c5d2b9e46670292d85c875ee9ec20e84ffb61",
+  },
+
+  {
+    account: "0x2546bcd3c84621e976d8185a91a922ae77ecec30",
+    privateKey: "0xea6c44ac03bff858b476bba40716402b03e41b8e97e276d1baec7c37d42484a0",
+  },
+
+  {
+    account: "0xbda5747bfd65f08deb54cb465eb87d40e51b197e",
+    privateKey: "0x689af8efa8c651a91ad287602527f3af2fe9f6501a7ac4b061667b5a93e037fd",
+  },
+
+  {
+    account: "0xdd2fd4581271e230360230f9337d5c0430bf44c0",
+    privateKey: "0xde9be858da4a475276426320d5e9262ecfc3ba460bfac56360bfa6c4c28b4ee0",
+  },
+
+  // 19
+  {
+    account: "0x8626f6940e2eb28930efb4cef49b2d1f2c9c1199",
+    privateKey: "0xdf57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e",
+  },
+];

--- a/src/test/testAccounts.ts
+++ b/src/test/testAccounts.ts
@@ -1,6 +1,6 @@
 import { ContractTransaction, ethers } from "ethers";
-import { getConfig } from "../config/config";
-import { register, Registration } from "../contracts/registry";
+import { getConfig } from "../config";
+import { register, Registration } from "../core/contracts/registry";
 import { Identity__factory, Registry__factory } from "../types/typechain";
 
 export interface RegistrationWithSigner extends Registration {


### PR DESCRIPTION
Problem
=======
>As the App API, I need to know if a public key has a given permission on a given contract So that I can test a generic signature against a DSNP Id

[Pivotal Tracker #178267391](https://www.pivotaltracker.com/story/show/178267391)

Solution
========
* new plumbing function contracts/registry.ts#validateMessage
* tests for same
* added some test helpers in testAccounts.ts which let you set up a new signer and easily create a new DSNP identity with a new handle all in one go, using the specified test account by its index.

Steps to Verify:
----------------
1. tests should all pass
