### PR TITLE
Fix CI for Releases

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -3,10 +3,10 @@ on:
   push:
     branches: [ main ]
 jobs:
-  test:
+  publish-to-npm-next:
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout
+      - name: Checkout 🛎️
         uses: actions/checkout@v2
 
       - name: Use Node.js
@@ -25,7 +25,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Install
+      - name: Install 💾
         run: npm ci
 
       - name: Version ⬆️

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,14 @@ on:
 jobs:
   publish-to-npm:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: [14.15.5]
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
         with:
+          node-version: '14.15.5'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm to v7
@@ -39,12 +38,17 @@ jobs:
 
   build-and-deploy:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: [ 14.15.5 ]
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.15.5'
+
+      - name: Update npm to v7
+        run: npm i -g npm
 
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
Problem
=======
For some reason the npm v7 upgrade would not work with the matrix strategy (`npm i -g npm`) and failed.

Solution
========
Switched over to the form used by the `@next` release setup
