### PR TITLE
getters & refactors

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,6 +1,15 @@
 import { providers, Wallet } from "ethers";
-import { getConfig, setConfig, Config, getQueue, ConfigOpts, requireGetConfig } from "./config";
-import { MissingStore, MissingUser } from "./core/utilities";
+import {
+  getConfig,
+  setConfig,
+  Config,
+  getQueue,
+  ConfigOpts,
+  MissingStore,
+  MissingUser,
+  requireGetConfig,
+} from "./config";
+import {} from "./core/utilities";
 
 describe("config", () => {
   describe("#getConfig", () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,13 +1,15 @@
-import { getConfig, setConfig, Config } from "./config";
+import { providers, Wallet } from "ethers";
+import { getConfig, setConfig, Config, getQueue, ConfigOpts, requireGetConfig } from "./config";
+import { MissingStore, MissingUser } from "./core/utilities";
 
 describe("config", () => {
   describe("#getConfig", () => {
     it("returns the default settings when the config hasn't been set yet", () => {
-      const results = getConfig();
+      const queue = getQueue();
 
       // We have to test keys here because #toMatchObject doesn't work with
       // object instances
-      expect(results["queue"]).toBeInstanceOf(Object);
+      expect(queue).toBeInstanceOf(Object);
     });
 
     it("fetches the current config settings", () => {
@@ -47,6 +49,47 @@ describe("config", () => {
       setConfig(testConfig);
 
       expect(getConfig()).toMatchObject({ test: "object" });
+    });
+  });
+
+  describe("getConfigOrThrow", () => {
+    // get a minimal valid config
+    describe("when config is missing required params", () => {
+      it("throws when something is missing", () => {
+        const testConfig = {
+          signer: Wallet.createRandom(),
+          provider: new providers.JsonRpcProvider("http://localhost:8383"),
+        };
+        setConfig(testConfig);
+        expect(() => requireGetConfig(["signer", "provider", "currentFromId"])).toThrow(MissingUser);
+      });
+
+      it("throws when we require invalid config", () => {
+        expect(() => requireGetConfig(["singer"])).toThrow("unknown config: singer");
+      });
+
+      it("throws when the config key exists but its value is undefined", () => {
+        setConfig({
+          provider: undefined,
+          store: undefined,
+          signer: undefined,
+          currentFromId: undefined,
+        });
+        expect(() => requireGetConfig(["store", "currentFromId", "provider", "signer"])).toThrow(MissingStore);
+      });
+    });
+
+    describe("when config has all expected values", () => {
+      const testConfig: ConfigOpts = getConfig();
+
+      [
+        { name: "when passed no params", require: [] },
+        { name: "when passed params that exist", require: ["queue", "contracts"] },
+      ].forEach((tc) => {
+        it(`${tc.name} returns config`, () => {
+          expect(requireGetConfig([])).toEqual(testConfig);
+        });
+      });
     });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,12 @@ import MemoryQueue from "./core/queue/memoryQueue";
 import { QueueInterface } from "./core/queue";
 import { StoreInterface } from "./core/store";
 import { HexString } from "./types/Strings";
-import { MissingProvider, MissingSigner, MissingStore, MissingUser } from "./core/utilities";
+
+export const MissingContract = new Error("Contract was not found");
+export const MissingSigner = new Error("Signer is not set.");
+export const MissingProvider = new Error("Blockchain provider is not set.");
+export const MissingStore = new Error("Store adapter was not found");
+export const MissingUser = new Error("No user id found. Please authenticate a handle.");
 
 export interface Contracts {
   /** The Address of the Batch Announce contract */
@@ -54,7 +59,7 @@ let config: Config = {
 /**
  * getConfig() fetches the current configuration settings and returns them.
  *
- * @returns The current configuration settings
+ * @returns The current configuration settings with ConfigOpts as overrides.
  */
 export const getConfig = (overrides?: ConfigOpts): Config => {
   if (!overrides) return config;
@@ -83,40 +88,66 @@ export const setConfig = (newConfig: ConfigOpts): Config => {
   });
 };
 
-// - Update all `getConfig()` calls to use these getters where appropriate
-// - Move associated "Missing" errors to the config module
+/**
+ * Get the provider and if undefined, throw.
+ * @param opts overrides for the current configuration.
+ */
 export const requireGetProvider = (opts?: ConfigOpts): ethers.providers.Provider => {
   const c = getConfig(opts);
   if (!c.provider) throw MissingProvider;
   return c.provider;
 };
+
+/**
+ * Get the signer and if undefined, throw.
+ * @param opts overrides for the current configuration.
+ */
 export const requireGetSigner = (opts?: ConfigOpts): ethers.Signer => {
   const c = getConfig(opts);
   if (!c.signer) throw MissingSigner;
   return c.signer;
 };
+
+/**
+ * Get the store and if undefined, throw.
+ * @param opts overrides for the current configuration.
+ */
 export const requireGetStore = (opts?: ConfigOpts): StoreInterface => {
   const c = getConfig(opts);
   if (!c.store) throw MissingStore;
   return c.store;
 };
+
+/**
+ * Get the currentFromId and if undefined, throw.
+ * @param opts overrides for the current configuration.
+ */
 export const requireGetCurrentFromId = (opts?: ConfigOpts): string => {
   const c = getConfig(opts);
   if (!c.currentFromId) throw MissingUser;
   return c.currentFromId;
 };
+
+/**
+ * Get the queue.  Since this is a required field, this is a plain getter.
+ * @param opts overrides for the current configuration.
+ */
 export const getQueue = (opts?: ConfigOpts): QueueInterface => {
   const c = getConfig(opts);
   return c.queue;
 };
 
+/**
+ * Get the contracts.  Since this is a required field, this is a plain getter.
+ * @param opts overrides for the current configuration.
+ */
 export const getContracts = (opts?: ConfigOpts): Contracts => {
   const c = getConfig(opts);
   return c.contracts;
 };
 
 /**
- * use if you need to guarantee that >1 configs are set
+ * Get the full configuration. Use if you need to guarantee that >1 configs are set
  * @param requiredConfigs: list of config strings
  * @param opts
  */

--- a/src/content.test.ts
+++ b/src/content.test.ts
@@ -5,7 +5,7 @@ import * as config from "./config";
 import * as content from "./content";
 import { DSNPType } from "./core/messages/messages";
 import TestStore from "./test/testStore";
-import { MissingSigner, MissingStoreError, MissingUser } from "./core/utilities";
+import { MissingSigner, MissingStore, MissingUser } from "./core/utilities";
 
 describe("content", () => {
   describe("broadcast", () => {
@@ -103,7 +103,7 @@ describe("content", () => {
             content: "Lorem ipsum delor blah blah blah",
             name: "Lorem Ipsum",
           })
-        ).rejects.toThrow(MissingStoreError);
+        ).rejects.toThrow(MissingStore);
       });
     });
 
@@ -255,7 +255,7 @@ describe("content", () => {
             },
             "dsnp://0123456789ABCDEF/0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
           )
-        ).rejects.toThrow(MissingStoreError);
+        ).rejects.toThrow(MissingStore);
       });
     });
 
@@ -430,7 +430,7 @@ describe("content", () => {
             name: "Rose Karr",
             preferredUsername: "rosalinekarr",
           })
-        ).rejects.toThrow(MissingStoreError);
+        ).rejects.toThrow(MissingStore);
       });
     });
 

--- a/src/content.test.ts
+++ b/src/content.test.ts
@@ -5,7 +5,6 @@ import * as config from "./config";
 import * as content from "./content";
 import { DSNPType } from "./core/messages/messages";
 import TestStore from "./test/testStore";
-import { MissingSigner, MissingStore, MissingUser } from "./core/utilities";
 
 describe("content", () => {
   describe("broadcast", () => {
@@ -86,7 +85,7 @@ describe("content", () => {
             content: "Lorem ipsum delor blah blah blah",
             name: "Lorem Ipsum",
           })
-        ).rejects.toThrow(MissingSigner);
+        ).rejects.toThrow(config.MissingSigner);
       });
     });
 
@@ -103,7 +102,7 @@ describe("content", () => {
             content: "Lorem ipsum delor blah blah blah",
             name: "Lorem Ipsum",
           })
-        ).rejects.toThrow(MissingStore);
+        ).rejects.toThrow(config.MissingStore);
       });
     });
 
@@ -120,7 +119,7 @@ describe("content", () => {
             content: "Lorem ipsum delor blah blah blah",
             name: "Lorem Ipsum",
           })
-        ).rejects.toThrow(MissingUser);
+        ).rejects.toThrow(config.MissingUser);
       });
     });
   });
@@ -234,7 +233,7 @@ describe("content", () => {
             },
             "dsnp://0123456789ABCDEF/0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
           )
-        ).rejects.toThrow(MissingSigner);
+        ).rejects.toThrow(config.MissingSigner);
       });
     });
 
@@ -255,7 +254,7 @@ describe("content", () => {
             },
             "dsnp://0123456789ABCDEF/0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
           )
-        ).rejects.toThrow(MissingStore);
+        ).rejects.toThrow(config.MissingStore);
       });
     });
 
@@ -276,7 +275,7 @@ describe("content", () => {
             },
             "dsnp://0123456789ABCDEF/0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
           )
-        ).rejects.toThrow(MissingUser);
+        ).rejects.toThrow(config.MissingUser);
       });
     });
   });
@@ -316,7 +315,7 @@ describe("content", () => {
             "🏴‍☠️",
             "dsnp://0123456789ABCDEF/0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
           )
-        ).rejects.toThrow(MissingSigner);
+        ).rejects.toThrow(config.MissingSigner);
       });
     });
 
@@ -331,7 +330,7 @@ describe("content", () => {
             "🏴‍☠️",
             "dsnp://0123456789ABCDEF/0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
           )
-        ).rejects.toThrow(MissingUser);
+        ).rejects.toThrow(config.MissingUser);
       });
     });
   });
@@ -413,7 +412,7 @@ describe("content", () => {
             name: "Rose Karr",
             preferredUsername: "rosalinekarr",
           })
-        ).rejects.toThrow(MissingSigner);
+        ).rejects.toThrow(config.MissingSigner);
       });
     });
 
@@ -430,7 +429,7 @@ describe("content", () => {
             name: "Rose Karr",
             preferredUsername: "rosalinekarr",
           })
-        ).rejects.toThrow(MissingStore);
+        ).rejects.toThrow(config.MissingStore);
       });
     });
 
@@ -447,7 +446,7 @@ describe("content", () => {
             name: "Rose Karr",
             preferredUsername: "rosalinekarr",
           })
-        ).rejects.toThrow(MissingUser);
+        ).rejects.toThrow(config.MissingUser);
       });
     });
   });

--- a/src/content.ts
+++ b/src/content.ts
@@ -5,7 +5,7 @@ import * as batchMessages from "./core/batch/batchMesssages";
 import * as config from "./config";
 import * as messages from "./core/messages/messages";
 import * as store from "./core/store/interface";
-import { validateDSNPId, MissingUser } from "./core/utilities";
+import { validateDSNPId } from "./core/utilities";
 
 /**
  * InvalidActivityPubOpts represents an error in the activity pub options
@@ -39,8 +39,7 @@ export const broadcast = async (
   if (!activityPub.validate(contentObj)) throw InvalidActivityPubOpts;
   const content = activityPub.serialize(contentObj);
 
-  const { currentFromId } = config.getConfig(opts);
-  if (!currentFromId) throw MissingUser;
+  const currentFromId = config.requireGetCurrentFromId(opts);
 
   const contentHash = keccak256(content);
   const uri = await store.put(contentHash, content, opts);
@@ -72,8 +71,7 @@ export const reply = async (
   if (!activityPub.validateReply(contentObj)) throw InvalidActivityPubOpts;
   const content = activityPub.serialize(contentObj);
 
-  const { currentFromId } = config.getConfig(opts);
-  if (!currentFromId) throw MissingUser;
+  const currentFromId = config.requireGetCurrentFromId(opts);
 
   const contentHash = keccak256(content);
   const uri = await store.put(contentHash, content, opts);
@@ -97,8 +95,7 @@ export const react = async (
   inReplyTo: string,
   opts?: config.ConfigOpts
 ): Promise<batchMessages.BatchReactionMessage> => {
-  const { currentFromId } = config.getConfig(opts);
-  if (!currentFromId) throw MissingUser;
+  const currentFromId = config.requireGetCurrentFromId(opts);
 
   const message = messages.createReactionMessage(currentFromId, emoji, inReplyTo);
 
@@ -126,8 +123,7 @@ export const profile = async (
   if (!activityPub.validateProfile(contentObj)) throw InvalidActivityPubOpts;
   const content = activityPub.serialize(contentObj);
 
-  const { currentFromId } = config.getConfig(opts);
-  if (!currentFromId) throw MissingUser;
+  const currentFromId = config.requireGetCurrentFromId(opts);
 
   const contentHash = keccak256(content);
   const uri = await store.put(contentHash, content, opts);

--- a/src/core/contracts/announcement.ts
+++ b/src/core/contracts/announcement.ts
@@ -1,7 +1,6 @@
 import { ContractTransaction, ethers, EventFilter, Signer } from "ethers";
-import { ConfigOpts, requireGetProvider, requireGetConfig } from "../../config";
+import { ConfigOpts, requireGetProvider, requireGetConfig, MissingContract } from "../../config";
 import { HexString } from "../../types/Strings";
-import { MissingContract } from "../utilities";
 import { abi as announcerABI } from "@dsnp/contracts/abi/Announcer.json";
 import { Announcer, Announcer__factory } from "../../types/typechain";
 import { getContractAddress } from "./contract";

--- a/src/core/contracts/identity.test.ts
+++ b/src/core/contracts/identity.test.ts
@@ -13,7 +13,7 @@ import {
 import { EthAddressRegex } from "../../test/matchers";
 import { setupConfig } from "../../test/sdkTestConfig";
 import { snapshotSetup } from "../../test/hardhatRPC";
-import { MissingContract } from "../utilities";
+import { MissingContract } from "../../config";
 
 const owner = "0x70997970c51812dc3a010c7d01b50e0d17dc79c8";
 const nonOwner = "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc";

--- a/src/core/contracts/identity.ts
+++ b/src/core/contracts/identity.ts
@@ -1,6 +1,5 @@
 import { ContractTransaction, Signer } from "ethers";
-import { MissingProvider, MissingContract } from "../utilities";
-import { ConfigOpts, requireGetProvider, requireGetConfig } from "../../config";
+import { ConfigOpts, requireGetProvider, requireGetConfig, MissingProvider, MissingContract } from "../../config";
 import { EthereumAddress } from "../../types/Strings";
 import {
   IdentityCloneFactory,

--- a/src/core/messages/messages.ts
+++ b/src/core/messages/messages.ts
@@ -1,8 +1,7 @@
 import { ethers } from "ethers";
 
-import { getConfig, ConfigOpts } from "../../config";
+import { ConfigOpts, requireGetSigner } from "../../config";
 import { HexString } from "../../types/Strings";
-import { MissingSigner } from "../utilities/errors";
 import { sortObject } from "../utilities/json";
 import { DSNPBatchMessage } from "../batch/batchMesssages";
 
@@ -207,8 +206,7 @@ export const createProfileMessage = (fromId: string, uri: string, hash: HexStrin
  * @returns       The signed DSNP message
  */
 export const sign = async (message: DSNPMessage, opts?: ConfigOpts): Promise<DSNPBatchMessage> => {
-  const { signer } = await getConfig(opts);
-  if (!signer) throw MissingSigner;
+  const signer = requireGetSigner(opts);
   const signature = await signer.signMessage(serialize(message));
   return {
     ...message,

--- a/src/core/store/interface.test.ts
+++ b/src/core/store/interface.test.ts
@@ -1,5 +1,5 @@
 import { getConfig } from "../../config";
-import { MissingStoreError, NotImplementedError } from "../utilities";
+import { MissingStore, NotImplementedError } from "../utilities";
 import { get, put } from "./interface";
 
 jest.mock("../../config");
@@ -12,7 +12,7 @@ describe("store", () => {
       });
 
       it("throws MissingStoreError error", async () => {
-        await expect(get("file.txt")).rejects.toThrow(MissingStoreError);
+        await expect(get("file.txt")).rejects.toThrow(MissingStore);
       });
 
       describe("and #get function is not set", () => {
@@ -49,7 +49,7 @@ describe("store", () => {
       });
 
       it("throws MissingStoreError error", async () => {
-        await expect(put("file.txt", "{}")).rejects.toThrow(MissingStoreError);
+        await expect(put("file.txt", "{}")).rejects.toThrow(MissingStore);
       });
     });
 

--- a/src/core/store/interface.test.ts
+++ b/src/core/store/interface.test.ts
@@ -1,5 +1,5 @@
-import { getConfig } from "../../config";
-import { MissingStore, NotImplementedError } from "../utilities";
+import { MissingStore, requireGetStore } from "../../config";
+import { NotImplementedError } from "../utilities";
 import { get, put } from "./interface";
 
 jest.mock("../../config");
@@ -7,20 +7,14 @@ jest.mock("../../config");
 describe("store", () => {
   describe("#get", () => {
     describe("when store configuration is not set", () => {
-      beforeEach(() => {
-        (getConfig as jest.Mock).mockReturnValue({});
-      });
-
       it("throws MissingStoreError error", async () => {
+        (requireGetStore as jest.Mock).mockReturnValue({});
         await expect(get("file.txt")).rejects.toThrow(MissingStore);
       });
 
       describe("and #get function is not set", () => {
-        beforeEach(() => {
-          (getConfig as jest.Mock).mockReturnValue({ store: {} });
-        });
-
         it("throws MissingStoreError error", async () => {
+          (requireGetStore as jest.Mock).mockReturnValue({ put: jest.fn() });
           await expect(get("file.txt")).rejects.toThrow(NotImplementedError);
         });
       });
@@ -28,10 +22,9 @@ describe("store", () => {
 
     describe("when store is configured", () => {
       const getMock = jest.fn();
-      const storeMock = { get: getMock };
 
       beforeEach(() => {
-        (getConfig as jest.Mock).mockReturnValue({ store: storeMock });
+        (requireGetStore as jest.Mock).mockReturnValue({ get: getMock });
       });
 
       it("calls #get", async () => {
@@ -45,7 +38,7 @@ describe("store", () => {
   describe("#put", () => {
     describe("when store configuration is not set", () => {
       beforeEach(() => {
-        (getConfig as jest.Mock).mockReturnValue({});
+        (requireGetStore as jest.Mock).mockReturnValue({});
       });
 
       it("throws MissingStoreError error", async () => {
@@ -55,10 +48,9 @@ describe("store", () => {
 
     describe("when store is configured", () => {
       const putMock = jest.fn();
-      const storeMock = { put: putMock };
 
       beforeEach(() => {
-        (getConfig as jest.Mock).mockReturnValue({ store: storeMock });
+        (requireGetStore as jest.Mock).mockReturnValue({ put: putMock });
       });
 
       it("calls #put", async () => {

--- a/src/core/store/interface.ts
+++ b/src/core/store/interface.ts
@@ -1,5 +1,5 @@
 import { getConfig, ConfigOpts } from "../../config";
-import { MissingStoreError, NotImplementedError } from "../utilities/errors";
+import { MissingStore, NotImplementedError } from "../utilities/errors";
 
 export type File = Buffer | string;
 export type Content = string | Buffer;
@@ -25,7 +25,7 @@ export interface StoreInterface {
  */
 export const put = async (targetPath: string, content: Content, opts?: ConfigOpts): Promise<URL> => {
   const { store } = getConfig(opts);
-  if (!store) throw MissingStoreError;
+  if (!store) throw MissingStore;
 
   return await store.put(targetPath, content);
 };
@@ -39,7 +39,7 @@ export const put = async (targetPath: string, content: Content, opts?: ConfigOpt
  */
 export const get = async (targetPath: string, opts?: ConfigOpts): Promise<File> => {
   const { store } = getConfig(opts);
-  if (!store) throw MissingStoreError;
+  if (!store) throw MissingStore;
   if (!store.get) throw NotImplementedError;
 
   return await store.get(targetPath);

--- a/src/core/store/interface.ts
+++ b/src/core/store/interface.ts
@@ -1,5 +1,5 @@
-import { getConfig, ConfigOpts } from "../../config";
-import { MissingStore, NotImplementedError } from "../utilities/errors";
+import { ConfigOpts, requireGetStore } from "../../config";
+import { NotImplementedError } from "../utilities/errors";
 
 export type File = Buffer | string;
 export type Content = string | Buffer;
@@ -24,9 +24,7 @@ export interface StoreInterface {
  * @returns       The URI of the hosted file
  */
 export const put = async (targetPath: string, content: Content, opts?: ConfigOpts): Promise<URL> => {
-  const { store } = getConfig(opts);
-  if (!store) throw MissingStore;
-
+  const store = requireGetStore(opts);
   return await store.put(targetPath, content);
 };
 
@@ -38,8 +36,7 @@ export const put = async (targetPath: string, content: Content, opts?: ConfigOpt
  * @returns   The batch file fetched from the given URI
  */
 export const get = async (targetPath: string, opts?: ConfigOpts): Promise<File> => {
-  const { store } = getConfig(opts);
-  if (!store) throw MissingStore;
+  const store = requireGetStore(opts);
   if (!store.get) throw NotImplementedError;
 
   return await store.get(targetPath);

--- a/src/core/utilities/errors.ts
+++ b/src/core/utilities/errors.ts
@@ -2,5 +2,5 @@ export const NotImplementedError = new Error("This method is not yet implemented
 export const MissingSigner = new Error("Signer is not set.");
 export const MissingProvider = new Error("Blockchain provider is not set.");
 export const MissingContract = new Error("Contract was not found");
-export const MissingStoreError = new Error("Store adapter was not found");
+export const MissingStore = new Error("Store adapter was not found");
 export const MissingUser = new Error("No user id found. Please authenticate a handle.");

--- a/src/core/utilities/errors.ts
+++ b/src/core/utilities/errors.ts
@@ -1,6 +1,1 @@
 export const NotImplementedError = new Error("This method is not yet implemented.");
-export const MissingSigner = new Error("Signer is not set.");
-export const MissingProvider = new Error("Blockchain provider is not set.");
-export const MissingContract = new Error("Contract was not found");
-export const MissingStore = new Error("Store adapter was not found");
-export const MissingUser = new Error("No user id found. Please authenticate a handle.");

--- a/src/handles.test.ts
+++ b/src/handles.test.ts
@@ -49,7 +49,7 @@ describe("handles", () => {
   describe("#authenticateHandle", () => {
     it("sets the currentFromId correctly when a handle exists", async () => {
       await authenticateHandle("taken");
-      expect(config.getConfig().currentFromId).toEqual("dsnp://00000000000003e8");
+      expect(config.requireGetCurrentFromId()).toEqual("dsnp://00000000000003e8");
     });
 
     it("throws RegistrationNotFound when the handle does not exist", async () => {

--- a/src/network.test.ts
+++ b/src/network.test.ts
@@ -3,7 +3,6 @@ import * as network from "./network";
 import { findEvent } from "./core/contracts/contract";
 import { register } from "./core/contracts/registry";
 import { DSNPGraphChangeType, DSNPType } from "./core/messages/messages";
-import { MissingProvider, MissingSigner, MissingUser } from "./core/utilities";
 import { Identity__factory } from "./types/typechain";
 import { setupConfig } from "./test/sdkTestConfig";
 import { revertHardhat, snapshotHardhat, snapshotSetup } from "./test/hardhatRPC";
@@ -62,7 +61,7 @@ describe("network", () => {
           provider,
         });
 
-        await expect(network.follow("dril")).rejects.toThrow(MissingSigner);
+        await expect(network.follow("dril")).rejects.toThrow(config.MissingSigner);
       });
     });
 
@@ -73,7 +72,7 @@ describe("network", () => {
           provider,
         });
 
-        await expect(network.follow("dril")).rejects.toThrow(MissingUser);
+        await expect(network.follow("dril")).rejects.toThrow(config.MissingUser);
       });
     });
 
@@ -84,7 +83,7 @@ describe("network", () => {
           signer,
         });
 
-        await expect(network.follow("dril")).rejects.toThrow(MissingProvider);
+        await expect(network.follow("dril")).rejects.toThrow(config.MissingProvider);
       });
     });
   });
@@ -118,7 +117,7 @@ describe("network", () => {
           provider,
         });
 
-        await expect(network.unfollow("dril")).rejects.toThrow(MissingSigner);
+        await expect(network.unfollow("dril")).rejects.toThrow(config.MissingSigner);
       });
     });
 
@@ -129,7 +128,7 @@ describe("network", () => {
           provider,
         });
 
-        await expect(network.unfollow("dril")).rejects.toThrow(MissingUser);
+        await expect(network.unfollow("dril")).rejects.toThrow(config.MissingUser);
       });
     });
 
@@ -140,7 +139,7 @@ describe("network", () => {
           signer,
         });
 
-        await expect(network.unfollow("dril")).rejects.toThrow(MissingProvider);
+        await expect(network.unfollow("dril")).rejects.toThrow(config.MissingProvider);
       });
     });
   });

--- a/src/network.ts
+++ b/src/network.ts
@@ -3,7 +3,7 @@ import * as messages from "./core/messages/messages";
 import * as batchMessages from "./core/batch/batchMesssages";
 import * as config from "./config";
 import { RegistrationNotFound } from "./handles";
-import { MissingUser, NotImplementedError } from "./core/utilities";
+import { NotImplementedError } from "./core/utilities";
 
 /**
  * follow() creates a follow event and returns it.
@@ -16,8 +16,7 @@ export const follow = async (
   handle: Handle,
   opts?: config.ConfigOpts
 ): Promise<batchMessages.BatchGraphChangeMessage> => {
-  const { currentFromId } = config.getConfig(opts);
-  if (!currentFromId) throw MissingUser;
+  const currentFromId = config.requireGetCurrentFromId(opts);
 
   const registration = await resolveRegistration(handle);
   if (!registration) throw RegistrationNotFound;
@@ -40,8 +39,7 @@ export const unfollow = async (
   handle: Handle,
   opts?: config.ConfigOpts
 ): Promise<batchMessages.BatchGraphChangeMessage> => {
-  const { currentFromId } = config.getConfig(opts);
-  if (!currentFromId) throw MissingUser;
+  const currentFromId = config.requireGetCurrentFromId(opts);
 
   const registration = await resolveRegistration(handle);
   if (!registration) throw RegistrationNotFound;

--- a/src/test/testAccounts.ts
+++ b/src/test/testAccounts.ts
@@ -1,5 +1,5 @@
 import { ContractTransaction, ethers } from "ethers";
-import { getConfig } from "../config";
+import { requireGetProvider } from "../config";
 import { register, Registration } from "../core/contracts/registry";
 import { Identity__factory, Registry__factory } from "../types/typechain";
 import { bigNumberToDSNPUserId, DSNPUserId } from "../core/utilities/identifiers";
@@ -121,8 +121,7 @@ const TESTACCOUNTS = [
  */
 export const getSignerForAccount = (accountIndex: number): ethers.Signer => {
   if (accountIndex >= TESTACCOUNTS.length) throw new Error(`there are only ${TESTACCOUNTS.length} accounts.`);
-  const { provider } = getConfig();
-  if (!provider) throw new Error("no provider configured");
+  const provider = requireGetProvider();
   return new ethers.Wallet(TESTACCOUNTS[accountIndex].privateKey, provider);
 };
 


### PR DESCRIPTION
Problem
=======
Add getter methods to config module [link to Pivotal Tracker #178458945](https://www.pivotaltracker.com/story/show/178458945)

Solution
========
Proposed solution:
1. A bunch of `requireFoo` functions which pretty much replace all getters that are being used.  They always throw if Foo is undefined.
1. A requireGetConfig function to use if you want to guarantee multiple things are there.  Pass a list of strings (feels yucky, alternatives requested) and your configOpts.
1. Tests for above

I did not completely do a refactor because I wanted input before I did the rest.
