### PR TITLE
get rid of requireGetConfig, use single getters

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -75,7 +75,7 @@ export const getConfig = (overrides?: ConfigOpts): Config => {
  * setConfig() sets the current configuration with the given object.
  *
  * @params newConfig The configuration settings to set with
- * @return The newly constructed config
+ * @returns The newly constructed config
  */
 export const setConfig = (newConfig: ConfigOpts): Config => {
   const { signer, provider } = newConfig;
@@ -91,6 +91,7 @@ export const setConfig = (newConfig: ConfigOpts): Config => {
 /**
  * Get the provider and if undefined, throw.
  * @param opts overrides for the current configuration.
+ * @returns a never-undefined provider
  */
 export const requireGetProvider = (opts?: ConfigOpts): ethers.providers.Provider => {
   const c = getConfig(opts);
@@ -101,6 +102,7 @@ export const requireGetProvider = (opts?: ConfigOpts): ethers.providers.Provider
 /**
  * Get the signer and if undefined, throw.
  * @param opts overrides for the current configuration.
+ * @returns a never-undefined signer
  */
 export const requireGetSigner = (opts?: ConfigOpts): ethers.Signer => {
   const c = getConfig(opts);
@@ -111,6 +113,7 @@ export const requireGetSigner = (opts?: ConfigOpts): ethers.Signer => {
 /**
  * Get the store and if undefined, throw.
  * @param opts overrides for the current configuration.
+ * @returns a never-undefined store
  */
 export const requireGetStore = (opts?: ConfigOpts): StoreInterface => {
   const c = getConfig(opts);
@@ -121,6 +124,7 @@ export const requireGetStore = (opts?: ConfigOpts): StoreInterface => {
 /**
  * Get the currentFromId and if undefined, throw.
  * @param opts overrides for the current configuration.
+ * @returns a never-undefined currentFromId
  */
 export const requireGetCurrentFromId = (opts?: ConfigOpts): string => {
   const c = getConfig(opts);
@@ -144,32 +148,4 @@ export const getQueue = (opts?: ConfigOpts): QueueInterface => {
 export const getContracts = (opts?: ConfigOpts): Contracts => {
   const c = getConfig(opts);
   return c.contracts;
-};
-
-/**
- * Get the full configuration. Use if you need to guarantee that >1 configs are set
- * @param requiredConfigs: list of config strings
- * @param opts
- */
-export const requireGetConfig = (requiredConfigs?: Array<string>, opts?: ConfigOpts): Config => {
-  const c = getConfig(opts);
-  if (requiredConfigs) {
-    requiredConfigs.forEach((configKey) => {
-      if (c[configKey] === undefined) {
-        switch (configKey) {
-          case "store":
-            throw MissingStore;
-          case "signer":
-            throw MissingSigner;
-          case "provider":
-            throw MissingProvider;
-          case "currentFromId":
-            throw MissingUser;
-          default:
-            throw new Error("unknown config: " + configKey);
-        }
-      }
-    });
-  }
-  return c;
 };

--- a/src/core/contracts/announcement.ts
+++ b/src/core/contracts/announcement.ts
@@ -1,10 +1,9 @@
-import { ContractTransaction, ethers, EventFilter, Signer } from "ethers";
-import { ConfigOpts, requireGetProvider, requireGetConfig, MissingContract } from "../../config";
+import { ContractTransaction, ethers, EventFilter } from "ethers";
+import { ConfigOpts, requireGetProvider, MissingContract, getContracts, requireGetSigner } from "../../config";
 import { HexString } from "../../types/Strings";
 import { abi as announcerABI } from "@dsnp/contracts/abi/Announcer.json";
 import { Announcer, Announcer__factory } from "../../types/typechain";
 import { getContractAddress } from "./contract";
-import { Provider } from "@ethersproject/providers";
 
 const CONTRACT_NAME = "Announcer";
 
@@ -56,14 +55,12 @@ export const decodeDSNPBatchEvents = async (opts?: ConfigOpts): Promise<Announce
 };
 
 const getAnnouncerContract = async (opts?: ConfigOpts): Promise<Announcer> => {
-  const {
-    signer,
-    provider,
-    contracts: { announcer },
-  } = requireGetConfig(["signer", "provider"], opts);
+  const { announcer } = getContracts(opts);
+  const signer = requireGetSigner(opts);
+  const provider = requireGetProvider(opts);
 
-  const address = announcer || (await getContractAddress(provider as Provider, CONTRACT_NAME));
+  const address = announcer || (await getContractAddress(provider, CONTRACT_NAME));
 
   if (!address) throw MissingContract;
-  return Announcer__factory.connect(address, signer as Signer);
+  return Announcer__factory.connect(address, signer);
 };

--- a/src/core/contracts/identity.ts
+++ b/src/core/contracts/identity.ts
@@ -1,5 +1,12 @@
-import { ContractTransaction, Signer } from "ethers";
-import { ConfigOpts, requireGetProvider, requireGetConfig, MissingProvider, MissingContract } from "../../config";
+import { ContractTransaction } from "ethers";
+import {
+  ConfigOpts,
+  requireGetProvider,
+  MissingProvider,
+  MissingContract,
+  requireGetSigner,
+  getContracts,
+} from "../../config";
 import { EthereumAddress } from "../../types/Strings";
 import {
   IdentityCloneFactory,
@@ -93,40 +100,35 @@ export const createAndRegisterBeaconProxy = async (
 };
 
 const getIdentityLogicContractAddress = async (opts?: ConfigOpts): Promise<EthereumAddress> => {
-  const {
-    provider,
-    contracts: { identityLogic },
-  } = requireGetConfig(["provider"], opts);
-  const address = identityLogic || (await getContractAddress(provider as Provider, IDENTITY_CONTRACT));
+  const { identityLogic } = getContracts(opts);
+  const provider = requireGetProvider(opts);
+
+  const address = identityLogic || (await getContractAddress(provider, IDENTITY_CONTRACT));
 
   if (!address) throw MissingContract;
   return address;
 };
 
 const getIdentityCloneFactoryContract = async (opts?: ConfigOpts): Promise<IdentityCloneFactory> => {
-  const {
-    provider,
-    signer,
-    contracts: { identityCloneFactory },
-  } = requireGetConfig(["signer", "provider"], opts);
-  const address =
-    identityCloneFactory || (await getContractAddress(provider as Provider, IDENTITY_CLONE_FACTORY_CONTRACT));
+  const { identityCloneFactory } = getContracts(opts);
+  const signer = requireGetSigner(opts);
+  const provider = requireGetProvider(opts);
+
+  const address = identityCloneFactory || (await getContractAddress(provider, IDENTITY_CLONE_FACTORY_CONTRACT));
   if (!address) throw MissingContract;
 
-  return IdentityCloneFactory__factory.connect(address, signer as Signer);
+  return IdentityCloneFactory__factory.connect(address, signer);
 };
 
 const getBeaconFactoryContract = async (opts?: ConfigOpts): Promise<BeaconFactory> => {
-  const {
-    signer,
-    provider,
-    contracts: { beaconFactory },
-  } = requireGetConfig(["signer", "provider"], opts);
+  const { beaconFactory } = getContracts(opts);
+  const signer = requireGetSigner(opts);
+  const provider = requireGetProvider(opts);
 
-  const address = beaconFactory || (await getContractAddress(provider as Provider, BEACON_FACTORY_CONTRACT));
+  const address = beaconFactory || (await getContractAddress(provider, BEACON_FACTORY_CONTRACT));
   if (!address) throw MissingContract;
 
-  return BeaconFactory__factory.connect(address, signer as Signer);
+  return BeaconFactory__factory.connect(address, signer);
 };
 
 /**
@@ -153,10 +155,8 @@ export const isAuthorizedTo = async (
 };
 
 const getBeaconAddress = async (opts?: ConfigOpts): Promise<EthereumAddress> => {
-  const {
-    provider,
-    contracts: { beacon },
-  } = requireGetConfig(["provider"], opts);
+  const { beacon } = getContracts(opts);
+  const provider = requireGetProvider(opts);
   const address = beacon || (await getContractAddress(provider as Provider, BEACON_CONTRACT));
 
   if (!address) throw MissingContract;

--- a/src/core/contracts/registry.ts
+++ b/src/core/contracts/registry.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 import { getContractAddress, getVmError } from "./contract";
 import { EthereumAddress, HexString } from "../../types/Strings";
-import { ConfigOpts, MissingContract, requireGetSigner, requireGetProvider, requireGetConfig } from "../../config";
+import { ConfigOpts, MissingContract, requireGetSigner, requireGetProvider, getContracts } from "../../config";
 import { ContractTransaction } from "ethers";
 import { Registry__factory } from "../../types/typechain";
 import { Permission } from "./identity";
@@ -9,7 +9,6 @@ import { resolveId } from "../../handles";
 import { isAuthorizedTo } from "./identity";
 import { DSNPMessage, serialize } from "../messages";
 import { bigNumberToDSNPUserId, dsnpUserIdToBigNumber, DSNPUserId } from "../utilities/identifiers";
-import { Provider } from "@ethersproject/providers";
 
 const CONTRACT_NAME = "Registry";
 
@@ -159,12 +158,10 @@ export const isMessageSignatureAuthorizedTo = async (
 };
 
 const getContract = async (opts?: ConfigOpts) => {
-  const {
-    provider,
-    contracts: { registry },
-  } = requireGetConfig(["provider"], opts);
-  const address = registry || (await getContractAddress(provider as Provider, CONTRACT_NAME));
+  const { registry } = getContracts(opts);
+  const provider = requireGetProvider(opts);
+  const address = registry || (await getContractAddress(provider, CONTRACT_NAME));
 
   if (!address) throw MissingContract;
-  return Registry__factory.connect(address, provider as Provider);
+  return Registry__factory.connect(address, provider);
 };


### PR DESCRIPTION
Problem
=======
Follow up to #61 , after discussions and looking at the comments
[Finishes #178458945](https://www.pivotaltracker.com/story/show/178458945)

Solution
========
* requireGetConfig is gone.
* Use single getters if you want a guarantee that something is defined or will throw.
* Keeping 'requireGetFoo' and 'getFoo' where applicable as it's an indicator of what is returned; Configs that are not optional fields don't need a 'require' and getters for optional settings if you don't care if they aren't set can be implemented as needed.
* add @returns in typedocs
* tests for all the getters

This eliminates the code smell of using the "as Provider" and friends.
Code is even simpler than before.

Steps to Verify:
----------------
1. Tests pass.