### PR TITLE
Changed setConfig to preserve existing keys in the config when called

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -62,6 +62,20 @@ describe("config", () => {
 
       expect(getConfig()).toMatchObject({ test: "object" });
     });
+
+    it("does not remove existing keys in the config settings", async () => {
+      setConfig({
+        other_test: "blah blah",
+      });
+
+      const testConfig = ({
+        test: "object",
+      } as unknown) as Config;
+
+      setConfig(testConfig);
+
+      expect(getConfig()).toMatchObject({ other_test: "blah blah", test: "object" });
+    });
   });
 
   describe("requireGetters", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,7 +72,10 @@ export const getConfig = (overrides?: ConfigOpts): Config => {
 };
 
 /**
- * setConfig() sets the current configuration with the given object.
+ * setConfig() sets the current configuration with the given object. Any keys
+ * previously set on the config object will not be removed. To remove a config
+ * option, this method should be called with undefined passed for the given key
+ * to override it.
  *
  * @param newConfig - The configuration settings to set with
  * @returns The newly constructed config

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,9 +81,7 @@ export const setConfig = (newConfig: ConfigOpts): Config => {
   const { signer, provider } = newConfig;
   if (provider && signer && !signer.provider) newConfig.signer = signer.connect(provider);
   return (config = {
-    // Defaults
-    queue: new MemoryQueue(),
-    contracts: {},
+    ...config,
     ...newConfig,
   });
 };

--- a/src/content.test.ts
+++ b/src/content.test.ts
@@ -76,6 +76,7 @@ describe("content", () => {
       it("throws MissingStoreError", async () => {
         config.setConfig({
           currentFromId: "dsnp://0123456789ABCDEF",
+          signer: undefined,
           store: new TestStore(),
         });
 
@@ -94,6 +95,7 @@ describe("content", () => {
         config.setConfig({
           currentFromId: "dsnp://0123456789ABCDEF",
           signer: ethers.Wallet.createRandom(),
+          store: undefined,
         });
 
         await expect(
@@ -109,6 +111,7 @@ describe("content", () => {
     describe("without a user id", () => {
       it("throws MissingUser", async () => {
         config.setConfig({
+          currentFromId: undefined,
           signer: ethers.Wallet.createRandom(),
           store: new TestStore(),
         });
@@ -220,6 +223,7 @@ describe("content", () => {
       it("throws MissingStoreError", async () => {
         config.setConfig({
           currentFromId: "dsnp://0123456789ABCDEF",
+          signer: undefined,
           store: new TestStore(),
         });
 
@@ -242,6 +246,7 @@ describe("content", () => {
         config.setConfig({
           currentFromId: "dsnp://0123456789ABCDEF",
           signer: ethers.Wallet.createRandom(),
+          store: undefined,
         });
 
         await expect(
@@ -261,6 +266,7 @@ describe("content", () => {
     describe("without a user id", () => {
       it("throws MissingUser", async () => {
         config.setConfig({
+          currentFromId: undefined,
           signer: ethers.Wallet.createRandom(),
           store: new TestStore(),
         });
@@ -308,6 +314,7 @@ describe("content", () => {
       it("throws MissingUser", async () => {
         config.setConfig({
           currentFromId: "dsnp://0123456789ABCDEF",
+          signer: undefined,
         });
 
         await expect(
@@ -322,6 +329,7 @@ describe("content", () => {
     describe("without a user id", () => {
       it("throws MissingUser", async () => {
         config.setConfig({
+          currentFromId: undefined,
           signer: ethers.Wallet.createRandom(),
         });
 
@@ -403,6 +411,7 @@ describe("content", () => {
       it("throws MissingStoreError", async () => {
         config.setConfig({
           currentFromId: "dsnp://0123456789ABCDEF",
+          signer: undefined,
           store: new TestStore(),
         });
 
@@ -421,6 +430,7 @@ describe("content", () => {
         config.setConfig({
           currentFromId: "dsnp://0123456789ABCDEF",
           signer: ethers.Wallet.createRandom(),
+          store: undefined,
         });
 
         await expect(
@@ -436,6 +446,7 @@ describe("content", () => {
     describe("without a user id", () => {
       it("throws MissingUser", async () => {
         config.setConfig({
+          currentFromId: undefined,
           signer: ethers.Wallet.createRandom(),
           store: new TestStore(),
         });

--- a/src/network.test.ts
+++ b/src/network.test.ts
@@ -58,6 +58,7 @@ describe("network", () => {
       it("throws MissingUser", async () => {
         config.setConfig({
           currentFromId: "dsnp://0000000000000000",
+          signer: undefined,
           provider,
         });
 
@@ -68,6 +69,7 @@ describe("network", () => {
     describe("without a user id", () => {
       it("throws MissingUser", async () => {
         config.setConfig({
+          currentFromId: undefined,
           signer,
           provider,
         });
@@ -103,6 +105,7 @@ describe("network", () => {
       it("throws MissingUser", async () => {
         config.setConfig({
           currentFromId: "dsnp://0000000000000000",
+          signer: undefined,
           provider,
         });
 
@@ -113,6 +116,7 @@ describe("network", () => {
     describe("without a user id", () => {
       it("throws MissingUser", async () => {
         config.setConfig({
+          currentFromId: undefined,
           signer,
           provider,
         });


### PR DESCRIPTION
Problem
=======
We would prefer if the `setConfig()` method merged new config options with existing ones to avoid losing settings when called.
[#178559063](https://www.pivotaltracker.com/story/show/178559063)

Solution
========
Update it to do that