### PR TITLE
Fix BatchDSNPMessage types to not need coercion

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -47,7 +47,7 @@ export const broadcast = async (
   const message = messages.createBroadcastMessage(currentFromId, uri.toString(), contentHash);
 
   const signedMessage = await messages.sign(message, opts);
-  return signedMessage as batchMessages.BatchBroadcastMessage;
+  return signedMessage;
 };
 
 /**
@@ -79,7 +79,7 @@ export const reply = async (
   const message = messages.createReplyMessage(currentFromId, uri.toString(), contentHash, inReplyTo);
 
   const signedMessage = await messages.sign(message, opts);
-  return signedMessage as batchMessages.BatchReplyMessage;
+  return signedMessage;
 };
 
 /**
@@ -100,7 +100,7 @@ export const react = async (
   const message = messages.createReactionMessage(currentFromId, emoji, inReplyTo);
 
   const signedMessage = await messages.sign(message, opts);
-  return signedMessage as batchMessages.BatchReactionMessage;
+  return signedMessage;
 };
 
 /**
@@ -131,5 +131,5 @@ export const profile = async (
   const message = messages.createProfileMessage(currentFromId, uri.toString(), contentHash);
 
   const signedMessage = await messages.sign(message, opts);
-  return signedMessage as batchMessages.BatchProfileMessage;
+  return signedMessage;
 };

--- a/src/core/batch/batchMesssages.ts
+++ b/src/core/batch/batchMesssages.ts
@@ -1,31 +1,18 @@
 import {
   BroadcastMessage,
   DSNPMessage,
-  ReactionMessage,
-  ReplyMessage,
   GraphChangeMessage,
   ProfileMessage,
-} from "../messages/messages";
+  ReactionMessage,
+  ReplyMessage,
+} from "../messages";
 
-export interface BatchBroadcastMessage extends BroadcastMessage {
-  signature: string;
-}
-export interface BatchReplyMessage extends ReplyMessage {
-  signature: string;
-}
+export type DSNPMessageSigned<T extends DSNPMessage> = T & { signature: string };
 
-export interface BatchReactionMessage extends ReactionMessage {
-  signature: string;
-}
+export type DSNPBatchMessage = DSNPMessageSigned<DSNPMessage>;
 
-export interface BatchGraphChangeMessage extends GraphChangeMessage {
-  signature: string;
-}
-
-export interface BatchProfileMessage extends ProfileMessage {
-  signature: string;
-}
-
-export interface DSNPBatchMessage extends DSNPMessage {
-  signature: string;
-}
+export type BatchBroadcastMessage = DSNPMessageSigned<BroadcastMessage>;
+export type BatchReplyMessage = DSNPMessageSigned<ReplyMessage>;
+export type BatchReactionMessage = DSNPMessageSigned<ReactionMessage>;
+export type BatchProfileMessage = DSNPMessageSigned<ProfileMessage>;
+export type BatchGraphChangeMessage = DSNPMessageSigned<GraphChangeMessage>;

--- a/src/core/messages/messages.ts
+++ b/src/core/messages/messages.ts
@@ -3,7 +3,7 @@ import { ethers } from "ethers";
 import { ConfigOpts, requireGetSigner } from "../../config";
 import { HexString } from "../../types/Strings";
 import { sortObject } from "../utilities/json";
-import { DSNPBatchMessage } from "../batch/batchMesssages";
+import { DSNPMessageSigned } from "../batch/batchMesssages";
 
 /**
  * DSNPType: an enum representing different types of DSNP messages
@@ -205,7 +205,7 @@ export const createProfileMessage = (fromId: string, uri: string, hash: HexStrin
  * @param opts -    Optional. Configuration overrides, such as from address, if any
  * @returns       The signed DSNP message
  */
-export const sign = async (message: DSNPMessage, opts?: ConfigOpts): Promise<DSNPBatchMessage> => {
+export const sign = async <T extends DSNPMessage>(message: T, opts?: ConfigOpts): Promise<DSNPMessageSigned<T>> => {
   const signer = requireGetSigner(opts);
   const signature = await signer.signMessage(serialize(message));
   return {

--- a/src/network.ts
+++ b/src/network.ts
@@ -1,9 +1,9 @@
 import { Registration } from "./core/contracts/registry";
 import * as messages from "./core/messages/messages";
-import * as batchMessages from "./core/batch/batchMesssages";
 import * as config from "./config";
 import { NotImplementedError } from "./core/utilities";
 import { DSNPUserId } from "./core/utilities/identifiers";
+import { BatchGraphChangeMessage } from "./core/batch/batchMesssages";
 
 /**
  * follow() creates a follow event and returns it.
@@ -12,16 +12,13 @@ import { DSNPUserId } from "./core/utilities/identifiers";
  * @param opts - Optional. Configuration overrides, such as from address, if any
  * @returns The signed DSNP Graph Change message
  */
-export const follow = async (
-  followeeId: DSNPUserId,
-  opts?: config.ConfigOpts
-): Promise<batchMessages.BatchGraphChangeMessage> => {
+export const follow = async (followeeId: DSNPUserId, opts?: config.ConfigOpts): Promise<BatchGraphChangeMessage> => {
   const currentFromId = config.requireGetCurrentFromId(opts);
 
   const message = messages.createFollowGraphChangeMessage(currentFromId, followeeId);
 
   const signedMessage = await messages.sign(message, opts);
-  return signedMessage as batchMessages.BatchGraphChangeMessage;
+  return signedMessage;
 };
 
 /**
@@ -31,16 +28,13 @@ export const follow = async (
  * @param opts - Optional. Configuration overrides, such as from address, if any
  * @returns The signed DSNP Graph Change message
  */
-export const unfollow = async (
-  followeeId: DSNPUserId,
-  opts?: config.ConfigOpts
-): Promise<batchMessages.BatchGraphChangeMessage> => {
+export const unfollow = async (followeeId: DSNPUserId, opts?: config.ConfigOpts): Promise<BatchGraphChangeMessage> => {
   const currentFromId = config.requireGetCurrentFromId(opts);
 
   const message = messages.createFollowGraphChangeMessage(currentFromId, followeeId);
 
   const signedMessage = await messages.sign(message, opts);
-  return signedMessage as batchMessages.BatchGraphChangeMessage;
+  return signedMessage;
 };
 
 /**


### PR DESCRIPTION
Problem
=======
We had a type coercion which could lead to issues

Solution
========
Removed the coercion through building a generic type that used `& { key: value }` instead.

Change summary:
---------------
* Replaced BatchDSNPMessage with a better generic that works the same way.
