### PR TITLE
Features/sdk announce stream 178308136

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,9 @@ jobs:
     runs-on: ubuntu-20.04
     services:
       ganache:
-        image: unfinishedlabs/ganache-truffle-node:latest
+        image: dsnp/ganache:v0.1.0
         ports:
           - 8545:8545
-        options: >-
-          -e MNEMONIC="test test test test test test test test test test test junk"
-          -e CHAINID=31337
     steps:
       - name: Checkout SDK
         uses: actions/checkout@v2
@@ -39,41 +36,6 @@ jobs:
       - name: Install
         run: npm ci
         working-directory: ./main
-
-      - name: Find contracts package in SDK
-        id: contracts_version
-        run: |
-          npm list @dsnp/contracts
-          export version=`npm list @dsnp/contracts --silent | sed -En 's/.*contracts@0.0.0-(.{6}).*$/\1/p'`
-          export version=`[ "$version" ] || npm list @dsnp/contracts --silent | sed -En 's/.*contracts@(.*)$/v\1/p'`
-          echo "Found version ${version}"
-          git clone --bare https://github.com/LibertyDSNP/contracts.git contracts-temp
-          cd contracts-temp
-          export result=`git rev-parse $version`
-          [ "$result" ] || (echo "Unable to find the right git SHA for ${version}" && exit 1)
-          echo "Using SHA ${result}"
-          cd ..
-          rm -Rf ./contracts-temp
-          echo "contract_version=$result" >> $GITHUB_ENV
-        shell: bash
-        working-directory: ./main
-
-      - name: Checkout Contracts
-        uses: actions/checkout@v2
-        with:
-          repository: LibertyDSNP/contracts
-          path: contracts
-          ref: ${{ env.contract_version }}
-
-      - name: Install
-        run: npm ci
-        working-directory: ./contracts
-
-      - name: deploy contracts
-        run:  npm install hardhat && npm run build && npm run deploy:localhost
-        working-directory: ./contracts
-        env:
-          LOCAL_NETWORK_ACCOUNT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
       - name: Lint
         run: npm run lint

--- a/src/core/contracts/announcement.test.ts
+++ b/src/core/contracts/announcement.test.ts
@@ -1,8 +1,9 @@
 import { keccak256 } from "js-sha3";
 
-import { batch, decodeDSNPBatchEvents, Announcement } from "./announcement";
+import { batch, Announcement } from "./announcement";
 import { setupConfig } from "../../test/sdkTestConfig";
 import { setupSnapshot } from "../../test/hardhatRPC";
+import { requireGetProvider } from "../../config";
 
 describe("#batch", () => {
   setupSnapshot();
@@ -18,11 +19,11 @@ describe("#batch", () => {
     const announcements: Announcement[] = [{ dsnpType: 0, uri: testUri, hash: hash }];
 
     await batch(announcements);
-
-    const batchEvents = await decodeDSNPBatchEvents();
-
-    expect(batchEvents.length).toEqual(1);
-    expect(batchEvents[0].uri).toEqual(testUri);
-    expect(batchEvents[0].hash).toEqual(hash);
+    const provider = requireGetProvider();
+    const logs = await provider.getLogs({ fromBlock: "latest" });
+    expect(logs).toHaveLength(1);
+    expect(logs[0].data).toEqual(
+      "0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb65800000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000018687474703a2f2f7777772e74657374636f6e73742e636f6d0000000000000000"
+    );
   });
 });

--- a/src/core/contracts/announcement.ts
+++ b/src/core/contracts/announcement.ts
@@ -3,7 +3,6 @@ import { ConfigOpts, requireGetProvider, MissingContract, getContracts, requireG
 import { HexString } from "../../types/Strings";
 import { Announcer, Announcer__factory } from "../../types/typechain";
 import { getContractAddress } from "./contract";
-// import { LogDescription } from "@ethersproject/abi/src.ts/interface";
 
 const CONTRACT_NAME = "Announcer";
 

--- a/src/core/contracts/announcement.ts
+++ b/src/core/contracts/announcement.ts
@@ -1,9 +1,9 @@
-import { ContractTransaction, ethers, EventFilter } from "ethers";
+import { ContractTransaction, EventFilter } from "ethers";
 import { ConfigOpts, requireGetProvider, MissingContract, getContracts, requireGetSigner } from "../../config";
 import { HexString } from "../../types/Strings";
-import { abi as announcerABI } from "@dsnp/contracts/abi/Announcer.json";
 import { Announcer, Announcer__factory } from "../../types/typechain";
 import { getContractAddress } from "./contract";
+// import { LogDescription } from "@ethersproject/abi/src.ts/interface";
 
 const CONTRACT_NAME = "Announcer";
 
@@ -33,25 +33,6 @@ export const batch = async (announcements: Announcement[]): Promise<ContractTran
 export const dsnpBatchFilter = async (): Promise<EventFilter> => {
   const contract = await getAnnouncerContract();
   return contract.filters.DSNPBatch();
-};
-
-/**
- * Goes through logs finding all DNSPBatch events
- * @param opts - optional configuration
- * @returns All announcements recorded as DSNPBatch events
- */
-export const decodeDSNPBatchEvents = async (opts?: ConfigOpts): Promise<Announcement[]> => {
-  const provider = requireGetProvider(opts);
-  const filter = await dsnpBatchFilter();
-  const logs: ethers.providers.Log[] = await provider.getLogs(filter);
-  const decoder = new ethers.utils.Interface(announcerABI);
-  return logs
-    .map((log: ethers.providers.Log) => decoder.parseLog(log))
-    .filter((desc) => desc.name === "DSNPBatch")
-    .map((desc) => {
-      const { dsnpType, dsnpHash, dsnpUri } = desc.args;
-      return { dsnpType, hash: dsnpHash, uri: dsnpUri };
-    });
 };
 
 const getAnnouncerContract = async (opts?: ConfigOpts): Promise<Announcer> => {

--- a/src/core/contracts/subscription.test.ts
+++ b/src/core/contracts/subscription.test.ts
@@ -1,0 +1,174 @@
+import { keccak256 } from "js-sha3";
+
+import { batch, Announcement, dsnpBatchFilter } from "./announcement";
+import { batchAnnounceEvents } from "./subscription";
+import { setupConfig } from "../../test/sdkTestConfig";
+import { setupSnapshot } from "../../test/hardhatRPC";
+import { requireGetProvider } from "../../config";
+import { checkNumberOfFunctionCalls } from "../../test/utilities";
+import { BatchAnnounceCallbackArgs } from "./subscription";
+
+describe("subscription", () => {
+  setupSnapshot();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+    setupConfig();
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  describe("batchAnnounceEvents", () => {
+    jest.setTimeout(70000);
+    const testUri = "http://www.testconst.com";
+    const hash = "0x" + keccak256("test");
+
+    it("listen and retrieve batch announce events", async () => {
+      const provider = requireGetProvider();
+      const mock = jest.fn();
+
+      const removeListener = await batchAnnounceEvents(mock);
+      const announcements: Announcement[] = [{ dsnpType: 2, uri: testUri, hash: hash }];
+      await (await batch(announcements)).wait(1);
+      const numberOfCalls = await checkNumberOfFunctionCalls(mock, 30, 1);
+
+      const filter = await dsnpBatchFilter();
+      expect(numberOfCalls).toBeTruthy();
+
+      expect(mock.mock.calls[0][0].dsnpType).toEqual(2);
+      expect(mock.mock.calls[0][0].dsnpUri).toEqual(testUri);
+      expect(mock.mock.calls[0][0].dsnpHash).toEqual(hash);
+      await removeListener();
+      expect(provider.listeners(filter).length).toEqual(0);
+    });
+
+    it("calls the callback on each event", async () => {
+      const provider = requireGetProvider();
+
+      const testUri1 = "http://www.testconst111.com";
+      const hash1 = "0x" + keccak256("test111");
+      const testUri2 = "http://www.testconst222.com";
+      const hash2 = "0x" + keccak256("test222");
+
+      const mock = jest.fn();
+
+      const removeListener = await batchAnnounceEvents(mock);
+      const announcements: Announcement[] = [{ dsnpType: 2, uri: testUri1, hash: hash1 }];
+      const announcements1: Announcement[] = [{ dsnpType: 2, uri: testUri2, hash: hash2 }];
+      await (await batch(announcements)).wait(1);
+      await (await batch(announcements1)).wait(1);
+      const numberOfCalls = await checkNumberOfFunctionCalls(mock, 10, 2);
+      expect(numberOfCalls).toBeTruthy();
+
+      expect(mock).toHaveBeenCalledTimes(2);
+      await removeListener();
+      const filter = await dsnpBatchFilter();
+      expect(provider.listeners(filter).length).toEqual(0);
+    });
+
+    describe("when listener is removed", () => {
+      it("does not retrieve events", async () => {
+        const provider = requireGetProvider();
+        const filter = await dsnpBatchFilter();
+
+        const mock1 = jest.fn();
+        const removeListener = await batchAnnounceEvents(mock1);
+
+        expect(provider.listeners(filter).length).toEqual(1);
+        await removeListener();
+        expect(provider.listeners(filter).length).toEqual(0);
+      });
+    });
+  });
+
+  describe("batchAnnounce events with custom filter", () => {
+    it("returns events that matches filters", async () => {
+      const provider = requireGetProvider();
+      const mock = jest.fn((opts: BatchAnnounceCallbackArgs) => {
+        return opts;
+      });
+      const testUri3 = "http://www.testconst333.com";
+      const hash3 = "0x" + keccak256("test333");
+      const testUri4 = "http://www.testconst333.com";
+      const hash4 = "0x" + keccak256("test333");
+
+      const removeListener = await batchAnnounceEvents(mock, { dsnpType: 2 });
+      const announcements: Announcement[] = [{ dsnpType: 2, uri: testUri3, hash: hash3 }];
+      const announcements1: Announcement[] = [{ dsnpType: 4, uri: testUri4, hash: hash4 }];
+      await (await batch(announcements)).wait(1);
+      await (await batch(announcements1)).wait(1);
+      await checkNumberOfFunctionCalls(mock, 10, 1);
+      const filter = await dsnpBatchFilter();
+      expect(mock).toHaveBeenCalledTimes(1);
+      expect(mock.mock.calls[0][0].dsnpType).toEqual(2);
+      expect(mock.mock.calls[0][0].dsnpUri).toEqual(testUri3);
+      expect(mock.mock.calls[0][0].dsnpHash).toEqual(hash3);
+      await removeListener();
+      expect(provider.listeners(filter).length).toEqual(0);
+    });
+  });
+
+  describe("get past events from start block", () => {
+    it("retreives past events based on given start block", async () => {
+      const provider = requireGetProvider();
+      const mock = jest.fn();
+
+      const testUri3 = "http://www.testconst333.com";
+      const hash3 = "0x" + keccak256("test333");
+      const testUri4 = "http://www.testconst444.com";
+      const hash4 = "0x" + keccak256("test444");
+      const testUri5 = "http://www.testconst555.com";
+      const hash5 = "0x" + keccak256("test555");
+      const testUri6 = "http://www.testconst666.com";
+      const hash6 = "0x" + keccak256("test666");
+
+      const announcements: Announcement[] = [{ dsnpType: 2, uri: testUri3, hash: hash3 }];
+      const announcements1: Announcement[] = [{ dsnpType: 2, uri: testUri4, hash: hash4 }];
+      const announcements2: Announcement[] = [{ dsnpType: 2, uri: testUri5, hash: hash5 }];
+      const announcements3: Announcement[] = [{ dsnpType: 2, uri: testUri6, hash: hash6 }];
+
+      await (await batch(announcements)).wait(1);
+
+      const blockNumber = (await provider.getBlockNumber()) + 1;
+      await (await batch(announcements1)).wait(1);
+
+      const removeListener = await batchAnnounceEvents(mock, { dsnpType: 2, startBlock: blockNumber });
+
+      await (await batch(announcements2)).wait(1);
+      await (await batch(announcements3)).wait(1);
+
+      await checkNumberOfFunctionCalls(mock, 10, 3);
+
+      expect(mock).toHaveBeenCalledTimes(3);
+      expect(mock.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          dsnpUri: announcements1[0].uri,
+          dsnpHash: announcements1[0].hash,
+          dsnpType: announcements1[0].dsnpType,
+        })
+      );
+      expect(mock.mock.calls[1][0]).toEqual(
+        expect.objectContaining({
+          dsnpUri: announcements2[0].uri,
+          dsnpHash: announcements2[0].hash,
+          dsnpType: announcements2[0].dsnpType,
+        })
+      );
+      expect(mock.mock.calls[2][0]).toEqual(
+        expect.objectContaining({
+          dsnpUri: announcements3[0].uri,
+          dsnpHash: announcements3[0].hash,
+          dsnpType: announcements3[0].dsnpType,
+        })
+      );
+
+      const filter = await dsnpBatchFilter();
+      await removeListener();
+      expect(provider.listeners(filter).length).toEqual(0);
+    });
+  });
+});

--- a/src/core/contracts/subscription.test.ts
+++ b/src/core/contracts/subscription.test.ts
@@ -12,13 +12,10 @@ describe("subscription", () => {
   setupSnapshot();
 
   beforeEach(() => {
-    jest.clearAllMocks();
-    jest.resetAllMocks();
     setupConfig();
   });
 
   afterEach(async () => {
-    jest.clearAllMocks();
     jest.resetAllMocks();
   });
 

--- a/src/core/contracts/subscription.test.ts
+++ b/src/core/contracts/subscription.test.ts
@@ -1,7 +1,7 @@
 import { keccak256 } from "js-sha3";
 
 import { batch, Announcement, dsnpBatchFilter } from "./announcement";
-import { batchAnnounceEvents } from "./subscription";
+import { subscribeToBatchAnnounceEvents } from "./subscription";
 import { setupConfig } from "../../test/sdkTestConfig";
 import { setupSnapshot } from "../../test/hardhatRPC";
 import { requireGetProvider } from "../../config";
@@ -19,7 +19,7 @@ describe("subscription", () => {
     jest.resetAllMocks();
   });
 
-  describe("batchAnnounceEvents", () => {
+  describe("subscribeToBatchAnnounceEvents", () => {
     jest.setTimeout(70000);
     const testUri = "http://www.testconst.com";
     const hash = "0x" + keccak256("test");
@@ -28,7 +28,7 @@ describe("subscription", () => {
       const provider = requireGetProvider();
       const mock = jest.fn();
 
-      const removeListener = await batchAnnounceEvents(mock);
+      const removeListener = await subscribeToBatchAnnounceEvents(mock);
       const announcements: Announcement[] = [{ dsnpType: 2, uri: testUri, hash: hash }];
       await (await batch(announcements)).wait(1);
       const numberOfCalls = await checkNumberOfFunctionCalls(mock, 30, 1);
@@ -53,7 +53,7 @@ describe("subscription", () => {
 
       const mock = jest.fn();
 
-      const removeListener = await batchAnnounceEvents(mock);
+      const removeListener = await subscribeToBatchAnnounceEvents(mock);
       const announcements: Announcement[] = [{ dsnpType: 2, uri: testUri1, hash: hash1 }];
       const announcements1: Announcement[] = [{ dsnpType: 2, uri: testUri2, hash: hash2 }];
       await (await batch(announcements)).wait(1);
@@ -73,7 +73,7 @@ describe("subscription", () => {
         const filter = await dsnpBatchFilter();
 
         const mock1 = jest.fn();
-        const removeListener = await batchAnnounceEvents(mock1);
+        const removeListener = await subscribeToBatchAnnounceEvents(mock1);
 
         expect(provider.listeners(filter).length).toEqual(1);
         await removeListener();
@@ -93,7 +93,7 @@ describe("subscription", () => {
       const testUri4 = "http://www.testconst333.com";
       const hash4 = "0x" + keccak256("test333");
 
-      const removeListener = await batchAnnounceEvents(mock, { dsnpType: 2 });
+      const removeListener = await subscribeToBatchAnnounceEvents(mock, { dsnpType: 2 });
       const announcements: Announcement[] = [{ dsnpType: 2, uri: testUri3, hash: hash3 }];
       const announcements1: Announcement[] = [{ dsnpType: 4, uri: testUri4, hash: hash4 }];
       await (await batch(announcements)).wait(1);
@@ -133,7 +133,7 @@ describe("subscription", () => {
       const blockNumber = (await provider.getBlockNumber()) + 1;
       await (await batch(announcements1)).wait(1);
 
-      const removeListener = await batchAnnounceEvents(mock, { dsnpType: 2, startBlock: blockNumber });
+      const removeListener = await subscribeToBatchAnnounceEvents(mock, { dsnpType: 2, startBlock: blockNumber });
 
       await (await batch(announcements2)).wait(1);
       await (await batch(announcements3)).wait(1);

--- a/src/core/contracts/subscription.ts
+++ b/src/core/contracts/subscription.ts
@@ -7,7 +7,7 @@ import { Announcer__factory } from "../../types/typechain";
 const ANNOUNCER_DECODER = new ethers.utils.Interface(Announcer__factory.abi);
 
 /**
- * BatchAnnounceCallbackArgs: interface for callback function that is passed to batchAnnounceEvents
+ * BatchAnnounceCallbackArgs: interface for callback function that is passed to subscribeToBatchAnnounceEvents
  */
 export interface BatchAnnounceCallbackArgs {
   blockNumber: number;
@@ -29,7 +29,7 @@ interface batchFilterOptions {
 type BatchAnnounceCallback = (doReceiveAnnouncement: BatchAnnounceCallbackArgs) => void;
 
 /**
- * batchAnnounceEvents() sets up a listener to listen to retrieve Batch Announce events from the chain.
+ * subscribeToBatchAnnounceEvents() sets up a listener to listen to retrieve Batch Announce events from the chain.
  * It takes a callback and a filter. The filter is used to filter events that come through.
  * The callback is invoked for each correctly filtered event.
  *
@@ -37,7 +37,7 @@ type BatchAnnounceCallback = (doReceiveAnnouncement: BatchAnnounceCallbackArgs) 
  * @param filters -  Any filter options for including or excluding certain events
  * @returns        A function that can be called to remove listener for this type of event
  */
-export const batchAnnounceEvents = async (
+export const subscribeToBatchAnnounceEvents = async (
   doReceiveAnnouncement: BatchAnnounceCallback,
   filter?: batchFilterOptions
 ): Promise<() => void> => {

--- a/src/core/contracts/subscription.ts
+++ b/src/core/contracts/subscription.ts
@@ -1,0 +1,124 @@
+import { HexString } from "../../types/Strings";
+import { ethers } from "ethers";
+import { requireGetProvider } from "../../config";
+import { dsnpBatchFilter } from "./announcement";
+import { Filter } from "@ethersproject/abstract-provider";
+import { Announcer__factory } from "../../types/typechain";
+const ANNOUNCER_DECODER = new ethers.utils.Interface(Announcer__factory.abi);
+
+/**
+ * BatchAnnounceCallbackArgs: interface for callback function that is passed to batchAnnounceEvents
+ */
+export interface BatchAnnounceCallbackArgs {
+  blockNumber: number;
+  transactionHash: HexString;
+  dsnpType: number;
+  dsnpUri: string;
+  dsnpHash: HexString;
+}
+
+interface ParsedLog {
+  fragment: ethers.utils.LogDescription;
+  log: ethers.providers.Log;
+}
+
+interface batchFilterOptions {
+  dsnpType?: number;
+  startBlock?: number;
+}
+type BatchAnnounceCallback = (doReceiveAnnouncement: BatchAnnounceCallbackArgs) => void;
+
+/**
+ * batchAnnounceEvents() sets up a listener to listen to retrieve Batch Announce events from the chain.
+ * It takes a callback and a filter. The filter is used to filter events that come through.
+ * The callback is invoked for each correctly filtered event.
+ *
+ * @param callback - The callback function to be called when an event is received
+ * @param filters -  Any filter options for including or excluding certain events
+ * @returns        A function that can be called to remove listener for this type of event
+ */
+export const batchAnnounceEvents = async (
+  doReceiveAnnouncement: BatchAnnounceCallback,
+  filter?: batchFilterOptions
+): Promise<() => void> => {
+  let pastLogs: BatchAnnounceCallbackArgs[] = [];
+  const currentLogQueue: BatchAnnounceCallbackArgs[] = [];
+  const batchFilter: ethers.EventFilter = await dsnpBatchFilter();
+  const batchFilterWithOptions = filter ? createFilter(batchFilter, filter) : batchFilter;
+
+  const provider = requireGetProvider();
+  let maxBlockNumberForPastLogs = filter?.startBlock || 0;
+  let useQueue = filter?.startBlock != undefined;
+
+  provider.on(batchFilterWithOptions, (log: ethers.providers.Log) => {
+    const logItem = decodeLogsForBatchAnnounce([log])[0];
+
+    if (useQueue) {
+      currentLogQueue.push(logItem);
+    } else if (logItem.blockNumber > maxBlockNumberForPastLogs) {
+      doReceiveAnnouncement(logItem);
+    }
+  });
+
+  if (useQueue) {
+    pastLogs = await getPastLogs(provider, { fromBlock: filter?.startBlock });
+    maxBlockNumberForPastLogs = pastLogs[pastLogs.length - 1].blockNumber;
+
+    while (pastLogs.length > 0) {
+      const batchItem = pastLogs.shift();
+      if (batchItem) doReceiveAnnouncement(batchItem);
+    }
+
+    while (currentLogQueue.length > 0) {
+      const batchItem = currentLogQueue.shift();
+      if (batchItem && batchItem.blockNumber > maxBlockNumberForPastLogs) doReceiveAnnouncement(batchItem);
+    }
+
+    useQueue = false;
+  }
+
+  return () => {
+    provider.off(batchFilterWithOptions);
+  };
+};
+
+const createFilter = (batchFilter: ethers.EventFilter, filterOptions: batchFilterOptions) => {
+  const topics = batchFilter.topics ? batchFilter.topics : [];
+  const dsnpTypeTopic = filterOptions?.dsnpType ? "0x" + filterOptions.dsnpType.toString(16).padStart(64, "0") : null;
+  if (dsnpTypeTopic) {
+    topics.push(dsnpTypeTopic);
+  }
+
+  const finalFilter: ethers.providers.EventType = {
+    topics: topics,
+  };
+  return finalFilter;
+};
+
+const getPastLogs = async (
+  provider: ethers.providers.Provider,
+  filter: Filter
+): Promise<BatchAnnounceCallbackArgs[]> => {
+  const logs = await provider.getLogs(filter);
+  const formattedlogs = decodeLogsForBatchAnnounce(logs);
+
+  return formattedlogs;
+};
+
+const decodeLogsForBatchAnnounce = (logs: ethers.providers.Log[]): BatchAnnounceCallbackArgs[] => {
+  return logs
+    .map((log: ethers.providers.Log) => {
+      const fragment = ANNOUNCER_DECODER.parseLog(log);
+      return { fragment, log: log };
+    })
+    .filter((desc: ParsedLog) => desc.fragment.name === "DSNPBatch")
+    .map((item: ParsedLog) => {
+      return {
+        dsnpType: item.fragment.args.dsnpType,
+        dsnpHash: item.fragment.args.dsnpHash,
+        dsnpUri: item.fragment.args.dsnpUri,
+        blockNumber: item.log.blockNumber,
+        transactionHash: item.log.transactionHash,
+      };
+    });
+};

--- a/src/core/utilities/index.ts
+++ b/src/core/utilities/index.ts
@@ -4,8 +4,8 @@
  * export * from "./foo"
  * ```
  * Leads to use like:
- *   - `import { functionInFoo } from "@dsnp/sdk/utilities.ts";`
- *   - `import util from "@dsnp/sdk/utilities.ts"; util.functionInFoo();`
+ *   - `import { functionInFoo } from "@dsnp/sdk/utilities";`
+ *   - `import util from "@dsnp/sdk/utilities"; util.functionInFoo();`
  *
  * To export at a nested level:
  * ```
@@ -13,8 +13,8 @@
  * export const foo = fooImport;
  * ```
  * Leads to use like:
- *   - `import util from "@dsnp/sdk/utilities.ts"; util.foo.functionInFoo();`
- *   - `import { foo } from "@dsnp/sdk/utilities.ts"; foo.functionInFoo();`
+ *   - `import util from "@dsnp/sdk/utilities"; util.foo.functionInFoo();`
+ *   - `import { foo } from "@dsnp/sdk/utilities"; foo.functionInFoo();`
  */
 
 export * from "./errors";

--- a/src/core/utilities/index.ts
+++ b/src/core/utilities/index.ts
@@ -4,8 +4,8 @@
  * export * from "./foo"
  * ```
  * Leads to use like:
- *   - `import { functionInFoo } from "@dsnp/sdk/utilities";`
- *   - `import util from "@dsnp/sdk/utilities"; util.functionInFoo();`
+ *   - `import { functionInFoo } from "@dsnp/sdk/utilities.ts";`
+ *   - `import util from "@dsnp/sdk/utilities.ts"; util.functionInFoo();`
  *
  * To export at a nested level:
  * ```
@@ -13,8 +13,8 @@
  * export const foo = fooImport;
  * ```
  * Leads to use like:
- *   - `import util from "@dsnp/sdk/utilities"; util.foo.functionInFoo();`
- *   - `import { foo } from "@dsnp/sdk/utilities"; foo.functionInFoo();`
+ *   - `import util from "@dsnp/sdk/utilities.ts"; util.foo.functionInFoo();`
+ *   - `import { foo } from "@dsnp/sdk/utilities.ts"; foo.functionInFoo();`
  */
 
 export * from "./errors";

--- a/src/test/hardhatRPC.test.ts
+++ b/src/test/hardhatRPC.test.ts
@@ -2,7 +2,7 @@
 require("dotenv").config();
 import { ethers } from "ethers";
 import { keccak256 } from "js-sha3";
-import { batch, decodeDSNPBatchEvents } from "../core/contracts/announcement";
+import { batch, dsnpBatchFilter } from "../core/contracts/announcement";
 import { setConfig, getConfig } from "../config";
 import { snapshotHardhat, revertHardhat } from "./hardhatRPC";
 
@@ -23,6 +23,7 @@ beforeEach(async () => {
 
 describe("snapshot and revert", () => {
   it("clears changes after revert", async () => {
+    const filter = await dsnpBatchFilter();
     jest.setTimeout(12000);
 
     // snapshot
@@ -36,15 +37,15 @@ describe("snapshot and revert", () => {
     // create a batch
     await batch(announcements);
 
+    const batchEventLogs1 = await provider.getLogs(filter);
     // confirm batch event exists
-    const batchEvents1 = await decodeDSNPBatchEvents();
-    expect(batchEvents1.length).toEqual(1);
+    expect(batchEventLogs1.length).toEqual(1);
 
     // revert
     await revertHardhat(provider);
 
     // confirm batch event has been reverted
-    const batchEvents2 = await decodeDSNPBatchEvents();
-    expect(batchEvents2.length).toEqual(0);
+    const batchEventsLogs2 = await provider.getLogs(filter);
+    expect(batchEventsLogs2.length).toEqual(0);
   });
 });

--- a/src/test/hardhatRPC.ts
+++ b/src/test/hardhatRPC.ts
@@ -13,7 +13,6 @@ export const snapshotHardhat = async (provider: ethers.providers.JsonRpcProvider
 
 export const revertHardhat = async (provider: ethers.providers.JsonRpcProvider): Promise<void> => {
   const revertResponse = await provider.send("evm_revert", [latestSnapshot.pop()]);
-
   expect(revertResponse.error).toBeUndefined();
 };
 

--- a/src/test/sdkTestConfig.ts
+++ b/src/test/sdkTestConfig.ts
@@ -10,6 +10,8 @@ export const setupConfig = (): SdkTestConfig => {
   const RPC_URL = String(process.env.RPC_URL);
   const provider = new providers.JsonRpcProvider(RPC_URL);
   const signer = new Wallet(TESTING_PRIVATE_KEY);
+  // polling interval determines how often it checks for events on chain
+  provider.pollingInterval = 500;
   const conf = setConfig({
     signer,
     provider,

--- a/src/test/utilities.ts
+++ b/src/test/utilities.ts
@@ -1,0 +1,10 @@
+export const checkNumberOfFunctionCalls = async (
+  mockFn: jest.Mock,
+  timeOutSeconds: number,
+  times: number
+): Promise<boolean> => {
+  for (let i = 0; i < timeOutSeconds && mockFn.mock.calls.length < times; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  return mockFn.mock.calls.length >= times;
+};


### PR DESCRIPTION
Problem
=======
We need a way to be able to consistently listen for and retrieve batchAnnounce events that happen on chain
[link to Pivotal Tracker #178308136](https://www.pivotaltracker.com/story/show/178308136)

Solution
========
We added a function that sets up a listener to listen for and returns batchAnnounce events from the chain. 
This function takes a callback and a filter - and will filter through events and then invoke the callback for each filtered event.

with @wilwade 

Change summary:
---------------
* Add a new `subscription.ts` module
* Add functionality to set up listener in function `batchAnnounceEvents`
* Add functionality to filter events in `batchAnnounceEvents`
* have `batchAnnounceEvents deal with retrieving both bast and current events`
* Add spec
* Add `utilities.ts` file in test with a `checkNumberOfFunctionCalls` function that waits for our callback to get called
* use new ganache container in circle so we no longer need to look for the contracts and deploy them to a container.