### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,45 @@
 # Changelog
 
-Changelog may be found in GitHub Releases: https://github.com/LibertyDSNP/sdk-ts/releases 
+## Unreleased
+### Changes
+- 
+### Added
+- 
+### Removed
+-
+### Fixed
+- 
+
+## [1.0.0] - 2021-06-22
+### Changes
+- Lots of updates and cleanups
+- Removed `requireGetConfig`: Use specific getters
+- Moved S3Node into examples 
+### Added
+- Reading and writing a batch file
+- Creating Announcement Messages
+- subscribeToBatchAnnounceEvents for getting batch announce events
+### Fixed
+- Exported Generators
+### Removed
+- aws client-s3 dependency
+
+## [0.1.0] - 2021-06-09
+### Added
+- Many things in place, but still several things may give NotImplementedYet errors.
+- There are two primary sections: "index" which is has all the exports that are at the top level and often due multiple things and "core" which are more functional and direct in nature
+- The Config interface should be relatively stable (although additions are possible)
+- Uses @dsnp/contracts v0.1.0
+- Contract writing code is complete
+
+### Deprecated
+- Node.JS Only
+
+
+## [0.0.1] - 2021-03-15
+### Added
+- Initial release
+- Core structure
+- Announce contract integration
+- NPM package publishing
+- Documentation generation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dsnp/sdk",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dsnp/sdk",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dsnp/contracts": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsnp/sdk",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "SDK Library for the DSNP",
   "type": "commonjs",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
### Changes
- Lots of updates and cleanups
- Removed `requireGetConfig`: Use specific getters
- Moved S3Node into examples 
### Added
- Reading and writing a batch file
- Creating Announcement Messages
- subscribeToBatchAnnounceEvents for getting batch announce events
### Fixed
- Exported Generators
### Removed
- aws client-s3 dependency