### PR TITLE
Chores/rename dsnp id to dsnp message id 178606293

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,19 @@
 
 ## Unreleased
 ### Changes
-- 
+- Renamed DSNPId to DSNPMessageId to avoid confusion with DSNPUserId
 ### Added
-- 
+-
 ### Removed
 -
 ### Fixed
-- 
+-
 
 ## [1.0.0] - 2021-06-22
 ### Changes
 - Lots of updates and cleanups
 - Removed `requireGetConfig`: Use specific getters
-- Moved S3Node into examples 
+- Moved S3Node into examples
 ### Added
 - Reading and writing a batch file
 - Creating Announcement Messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Changes
 - Renamed DSNPId to DSNPMessageId to avoid confusion with DSNPUserId
+- Renamed validateDSNPId to validateDSNPMessageId (breaking change)
 ### Added
 -
 ### Removed

--- a/src/content.ts
+++ b/src/content.ts
@@ -4,7 +4,7 @@ import * as activityPub from "./core/activityPub/activityPub";
 import * as batchMessages from "./core/batch/batchMessages";
 import * as config from "./config";
 import * as messages from "./core/messages/messages";
-import { validateDSNPId } from "./core/utilities";
+import { validateDSNPMessageId } from "./core/utilities";
 import { requireGetStore } from "./config";
 
 /**
@@ -14,10 +14,10 @@ import { requireGetStore } from "./config";
 export const InvalidActivityPubOpts = new Error("Invalid activity pub options.");
 
 /**
- * InvalidInReplyTo represents an error in the DSNP Id provided for the
+ * InvalidInReplyTo represents an error in the DSNP Message Id provided for the
  * inReplyTo parameter.
  */
-export const InvalidInReplyTo = new Error("Invalid DSNP Id for inReplyTo");
+export const InvalidInReplyTo = new Error("Invalid DSNP Message Id for inReplyTo");
 
 /**
  * broadcast() creates an activity pub file with the given content options,
@@ -56,7 +56,7 @@ export const broadcast = async (
  * creates a DSNP reply message for the hosted file for later announcement.
  *
  * @param contentOptions - Options for the activity pub content to generate
- * @param inReplyTo - The DSNP Id of the message that this message is in reply to
+ * @param inReplyTo - The DSNP Message Id of the message that this message is in reply to
  * @param opts - Optional. Configuration overrides, such as from address, if any
  * @returns A Signed DSNP Reply message ready for inclusion in a batch
  */
@@ -65,7 +65,7 @@ export const reply = async (
   inReplyTo: string,
   opts?: config.ConfigOpts
 ): Promise<batchMessages.BatchReplyMessage> => {
-  if (!validateDSNPId(inReplyTo)) throw InvalidInReplyTo;
+  if (!validateDSNPMessageId(inReplyTo)) throw InvalidInReplyTo;
 
   const contentObj = activityPub.create(contentOptions);
   if (!activityPub.isValidReply(contentObj)) throw InvalidActivityPubOpts;
@@ -87,7 +87,7 @@ export const reply = async (
  * react() creates a DSNP reaction message for later announcement.
  *
  * @param emoji - The emoji with which to react
- * @param inReplyTo - The DSNP Id of the message to which to react
+ * @param inReplyTo - The DSNP Message Id of the message to which to react
  * @param opts - Optional. Configuration overrides, such as from address, if any
  * @returns A Signed DSNP Reaction message ready for inclusion in a batch
  */

--- a/src/core/contracts/identity.test.ts
+++ b/src/core/contracts/identity.test.ts
@@ -125,7 +125,7 @@ describe("identity", () => {
     const handle = "flarp";
     const fakeAddress = "0x1Ea32de10D5a18e55DEBAf379B26Cc0c6952B168";
 
-    it("returns a Contract Transaction that can be resolved into a DSNP Message Id", async () => {
+    it("returns a Contract Transaction that can be resolved into a DSNP User Id", async () => {
       const transaction = await createAndRegisterBeaconProxy(fakeAddress, handle);
 
       const receipt = await transaction.wait(1);

--- a/src/core/contracts/identity.test.ts
+++ b/src/core/contracts/identity.test.ts
@@ -125,7 +125,7 @@ describe("identity", () => {
     const handle = "flarp";
     const fakeAddress = "0x1Ea32de10D5a18e55DEBAf379B26Cc0c6952B168";
 
-    it("returns a Contract Transaction that can be resolved into a DSNP Id", async () => {
+    it("returns a Contract Transaction that can be resolved into a DSNP Message Id", async () => {
       const transaction = await createAndRegisterBeaconProxy(fakeAddress, handle);
 
       const receipt = await transaction.wait(1);

--- a/src/core/contracts/identity.ts
+++ b/src/core/contracts/identity.ts
@@ -30,7 +30,7 @@ export enum Permission {
   DELEGATE_REMOVE,
 }
 /**
- * createCloneProxy(logic?: Ethereum Address ) Creates a new identity with the message sender as the owner
+ * createCloneProxy(logic?: Ethereum Address) Creates a new identity with the message sender as the owner
  *
  * @param logic - The address to use for the logic contract
  * @param opts - Optional. Configuration overrides, such as from address, if any
@@ -90,7 +90,7 @@ export const createBeaconProxyWithOwner = async (
 };
 
 /**
- * Create a new identity and register it to a handle to get a new DSNP Message Id.
+ * Create a new identity and register it to a handle to get a new DSNP User Id.
  * This will create and register a new beacon proxy identity.
  *
  * @param userAddress - User's public key address

--- a/src/core/contracts/identity.ts
+++ b/src/core/contracts/identity.ts
@@ -90,7 +90,7 @@ export const createBeaconProxyWithOwner = async (
 };
 
 /**
- * Create a new identity and register it to a handle to get a new DSNP Id.
+ * Create a new identity and register it to a handle to get a new DSNP Message Id.
  * This will create and register a new beacon proxy identity.
  *
  * @param userAddress - User's public key address

--- a/src/core/contracts/registry.test.ts
+++ b/src/core/contracts/registry.test.ts
@@ -85,7 +85,7 @@ describe("registry", () => {
       await expect(pendingTx).transactionRejectsWith(/Handle already exists/);
     });
 
-    it("returns a Contract Transaction that can be resolved into a DSNP Message Id", async () => {
+    it("returns a Contract Transaction that can be resolved into a DSNP User Id", async () => {
       const transaction = await register(idContractAddr, "new-handle");
 
       expect(await getIdFromRegisterTransaction(transaction)).toEqual("dsnp://00000000000003e9"); // 1001

--- a/src/core/contracts/registry.test.ts
+++ b/src/core/contracts/registry.test.ts
@@ -85,7 +85,7 @@ describe("registry", () => {
       await expect(pendingTx).transactionRejectsWith(/Handle already exists/);
     });
 
-    it("returns a Contract Transaction that can be resolved into a DSNP Id", async () => {
+    it("returns a Contract Transaction that can be resolved into a DSNP Message Id", async () => {
       const transaction = await register(idContractAddr, "new-handle");
 
       expect(await getIdFromRegisterTransaction(transaction)).toEqual("dsnp://00000000000003e9"); // 1001

--- a/src/core/contracts/registry.ts
+++ b/src/core/contracts/registry.ts
@@ -21,11 +21,11 @@ export interface Registration {
 export type Handle = string;
 
 /**
- * resolveRegistration() Try to resolve a handle into a DSNP Message Id
+ * resolveRegistration() Try to resolve a handle into a DSNP User Id
  *
  * @param handle - String handle to resolve
  * @param opts - (optional) any config overrides.
- * @returns The Hex for the DSNP Message Id or null if not found
+ * @returns The Hex for the DSNP User Id or null if not found
  */
 export const resolveRegistration = async (handle: Handle, opts?: ConfigOpts): Promise<Registration | null> => {
   const contract = await getContract(opts);
@@ -47,7 +47,7 @@ export const resolveRegistration = async (handle: Handle, opts?: ConfigOpts): Pr
 };
 
 /**
- * register() registers a handle to get a new DSNP Message Id
+ * register() registers a handle to get a new DSNP User Id
  *
  * @param identityContractAddress - Address of the identity contract to use
  * @param handle - The string handle to register
@@ -66,7 +66,7 @@ export const register = async (
 };
 
 /**
- * changeAddress() changes the identity contract address of a DSNP Message Id
+ * changeAddress() changes the identity contract address of a DSNP User Id
  *
  * @param handle - The string handle to alter
  * @param identityContractAddress - Address of the new identity contract to use
@@ -84,7 +84,7 @@ export const changeAddress = async (
 };
 
 /**
- * changeHandle() changes the handle of a DSNP Message Id
+ * changeHandle() changes the handle of a DSNP User Id
  *
  * @param oldHandle - The string handle to alter
  * @param newHandle - The new handle to use instead

--- a/src/core/contracts/registry.ts
+++ b/src/core/contracts/registry.ts
@@ -21,11 +21,11 @@ export interface Registration {
 export type Handle = string;
 
 /**
- * resolveRegistration() Try to resolve a handle into a DSNP Id
+ * resolveRegistration() Try to resolve a handle into a DSNP Message Id
  *
  * @param handle - String handle to resolve
  * @param opts - (optional) any config overrides.
- * @returns The Hex for the DSNP Id or null if not found
+ * @returns The Hex for the DSNP Message Id or null if not found
  */
 export const resolveRegistration = async (handle: Handle, opts?: ConfigOpts): Promise<Registration | null> => {
   const contract = await getContract(opts);
@@ -47,7 +47,7 @@ export const resolveRegistration = async (handle: Handle, opts?: ConfigOpts): Pr
 };
 
 /**
- * register() registers a handle to get a new DSNP Id
+ * register() registers a handle to get a new DSNP Message Id
  *
  * @param identityContractAddress - Address of the identity contract to use
  * @param handle - The string handle to register
@@ -66,7 +66,7 @@ export const register = async (
 };
 
 /**
- * changeAddress() changes the identity contract address of a DSNP Id
+ * changeAddress() changes the identity contract address of a DSNP Message Id
  *
  * @param handle - The string handle to alter
  * @param identityContractAddress - Address of the new identity contract to use
@@ -84,7 +84,7 @@ export const changeAddress = async (
 };
 
 /**
- * changeHandle() changes the handle of a DSNP Id
+ * changeHandle() changes the handle of a DSNP Message Id
  *
  * @param oldHandle - The string handle to alter
  * @param newHandle - The new handle to use instead

--- a/src/core/utilities/identifiers.test.ts
+++ b/src/core/utilities/identifiers.test.ts
@@ -1,12 +1,12 @@
-import { validateDSNPId } from "./identifiers";
+import { validateDSNPMessageId } from "./identifiers";
 
-describe("validateDSNPId", () => {
-  const validDSNPIds = [
+describe("validateDSNPMessageId", () => {
+  const validDSNPMessageIds = [
     "dsnp://0123456789ABCDEF/0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF", // Uppercase
     "dsnp://0123456789abcdef/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", // Lowercase
   ];
 
-  const invalidDSNPIds = [
+  const invalidDSNPMessageIds = [
     "dsnp://badbadbad/0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF", // Bad user id
     "dsnp://0123456789ABCDEF/badbadbad", // Bad message id
     "dsnp://0123456789ABCDE/0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF", // User id too short
@@ -14,15 +14,15 @@ describe("validateDSNPId", () => {
     "dsnp://0123456789ABCDEF/0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDE", // Message id too short
   ];
 
-  for (const id of validDSNPIds) {
+  for (const id of validDSNPMessageIds) {
     it(`returns true for "${id}"`, () => {
-      expect(validateDSNPId(id)).toEqual(true);
+      expect(validateDSNPMessageId(id)).toEqual(true);
     });
   }
 
-  for (const id of invalidDSNPIds) {
+  for (const id of invalidDSNPMessageIds) {
     it(`returns false for "${id}"`, () => {
-      expect(validateDSNPId(id)).toEqual(false);
+      expect(validateDSNPMessageId(id)).toEqual(false);
     });
   }
 });

--- a/src/core/utilities/identifiers.ts
+++ b/src/core/utilities/identifiers.ts
@@ -1,20 +1,20 @@
 import { BigNumber } from "ethers";
 
 /**
- * DSNPId represents a DSNP message id following the DSNP
+ * DSNPMessageId represents a DSNP message id following the DSNP
  * [Message Identifiers](https://github.com/LibertyDSNP/spec/blob/main/pages/Messages/Identifiers.md)
  * specification.
  */
-export type DSNPId = string;
+export type DSNPMessageId = string;
 
 /**
- * validateDSNPId() validates a given string as a DSNPId. If the given string is
+ * validateDSNPMessageId() validates a given string as a DSNPMessageId. If the given string is
  * valid, true is returned. Otherwise, false is returned.
  *
  * @param id - The string to validate
- * @returns True of false depending on whether the string is a valid DSNPId
+ * @returns True of false depending on whether the string is a valid DSNPMessageId
  */
-export const validateDSNPId = (id: string): id is DSNPId => id.match(/dsnp:\/\/[0-9A-F]{16}\/[0-9A-F]{64}/i) !== null;
+export const validateDSNPMessageId = (id: string): id is DSNPMessageId => id.match(/dsnp:\/\/[0-9A-F]{16}\/[0-9A-F]{64}/i) !== null;
 
 /**
  * DSNPUserId represents a DSNP user id following the DSNP

--- a/src/core/utilities/identifiers.ts
+++ b/src/core/utilities/identifiers.ts
@@ -14,7 +14,8 @@ export type DSNPMessageId = string;
  * @param id - The string to validate
  * @returns True of false depending on whether the string is a valid DSNPMessageId
  */
-export const validateDSNPMessageId = (id: string): id is DSNPMessageId => id.match(/dsnp:\/\/[0-9A-F]{16}\/[0-9A-F]{64}/i) !== null;
+export const validateDSNPMessageId = (id: string): id is DSNPMessageId =>
+  id.match(/dsnp:\/\/[0-9A-F]{16}\/[0-9A-F]{64}/i) !== null;
 
 /**
  * DSNPUserId represents a DSNP user id following the DSNP

--- a/src/handles.ts
+++ b/src/handles.ts
@@ -51,13 +51,13 @@ export const updateRegistration = async (
  *
  * @param handle - The Registry Handle
  * @param opts - Optional. Configuration overrides, such as from address, if any
- * @returns The Registration object with Handle, DSNP Message Id, and Identity contract address
+ * @returns The Registration object with Handle, DSNP User Id, and Identity contract address
  */
 export const resolveHandle = (handle: Handle, opts?: config.ConfigOpts): Promise<Registration | null> =>
   resolveRegistration(handle, opts);
 
 /**
- * Get the current registration from a DSNP Message Id
+ * Get the current registration from a DSNP User Id
  *
  * @param dsnpUserId - The DSNP User Id
  * @param opts - Optional. Configuration overrides, such as from address, if any

--- a/src/handles.ts
+++ b/src/handles.ts
@@ -51,13 +51,13 @@ export const updateRegistration = async (
  *
  * @param handle - The Registry Handle
  * @param opts - Optional. Configuration overrides, such as from address, if any
- * @returns The Registration object with Handle, DSNP Id, and Identity contract address
+ * @returns The Registration object with Handle, DSNP Message Id, and Identity contract address
  */
 export const resolveHandle = (handle: Handle, opts?: config.ConfigOpts): Promise<Registration | null> =>
   resolveRegistration(handle, opts);
 
 /**
- * Get the current registration from a DSNP Id
+ * Get the current registration from a DSNP Message Id
  *
  * @param dsnpUserId - The DSNP User Id
  * @param opts - Optional. Configuration overrides, such as from address, if any

--- a/src/test/testAccounts.ts
+++ b/src/test/testAccounts.ts
@@ -127,10 +127,10 @@ export const getSignerForAccount = (accountIndex: number): ethers.Signer => {
 };
 
 /**
- * Parses a DSNP Message Id in a contract transaction log event.
+ * Parses a DSNP User Id in a contract transaction log event.
  *
  * @param transaction - The transaction to parse
- * @returns the DSNP Message Id
+ * @returns the DSNP User Id
  */
 export const getIdFromRegisterTransaction = async (transaction: ContractTransaction): Promise<DSNPUserId> => {
   const receipt = await transaction.wait(1);
@@ -140,7 +140,7 @@ export const getIdFromRegisterTransaction = async (transaction: ContractTransact
 };
 
 /**
- * Creates a new DSNP Message Identity Proxy contract using the specified test account, and registers the
+ * Creates a new DSNP Identity Proxy contract using the specified test account, and registers the
  * provided handle. Callers must keep track of what accounts have already been used.
  *
  * @param acctIdx - the index in TESTACCOUNTS to use.

--- a/src/test/testAccounts.ts
+++ b/src/test/testAccounts.ts
@@ -127,10 +127,10 @@ export const getSignerForAccount = (accountIndex: number): ethers.Signer => {
 };
 
 /**
- * Parses a DSNP Id in a contract transaction log event.
+ * Parses a DSNP Message Id in a contract transaction log event.
  *
  * @param transaction - The transaction to parse
- * @returns the DSNP Id
+ * @returns the DSNP Message Id
  */
 export const getIdFromRegisterTransaction = async (transaction: ContractTransaction): Promise<DSNPUserId> => {
   const receipt = await transaction.wait(1);
@@ -140,7 +140,7 @@ export const getIdFromRegisterTransaction = async (transaction: ContractTransact
 };
 
 /**
- * Creates a new DSNP Identity Proxy contract using the specified test account, and registers the
+ * Creates a new DSNP Message Identity Proxy contract using the specified test account, and registers the
  * provided handle. Callers must keep track of what accounts have already been used.
  *
  * @param acctIdx - the index in TESTACCOUNTS to use.


### PR DESCRIPTION
Problem
=======
We have to concepts of ids in the SDK: DSNP message ids and DSNP user ids, but we refer to message id as just `DSNPId`s which is confusing.
[#178606293](https://www.pivotaltracker.com/story/show/178606293)

Solution
========
Update all occurrences of DSNPId to DSNPMessageId.