### PR TITLE
chore(CI): swap Ganache for Harhat

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     services:
       ganache:
-        image: dsnp/ganache:v0.1.0
+        image: dsnp/hardhat:v0.1.0
         ports:
           - 8545:8545
     steps:


### PR DESCRIPTION
Swap Ganache for Hardhat. Version 6 of
Ganache has the chainid opcode hardcoded to 1. 
As a result, it prevents EIP-712 signatures from being valid.
The EIP-712 domain separator includes a chain-id that
will cause a discrepancy when signing and verifying
on-chain. 