### PR TITLE
Changed activity pub generators to use activity pub create method

### DIFF
--- a/src/generators/activityPubGenerators.test.ts
+++ b/src/generators/activityPubGenerators.test.ts
@@ -17,13 +17,15 @@ describe("activityPubGenerators", () => {
     expect(res.attributedTo).toEqual(from);
     expect(res.inReplyTo).toEqual(to);
     expect(res.type).toEqual("Note");
+    expect(res.published).toMatch(/(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/);
   });
 
-  it("activityPubGenerators does", () => {
+  it("generateNote does", () => {
     let res: ActivityPub = apg.generateNote(from, opText);
     expect(res.attachments).toEqual([]);
     expect(res.type).toEqual("Note");
     expect(res.inReplyTo).toBeUndefined();
+    expect(res.published).toMatch(/(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/);
 
     res = apg.generateNote(from, opText, true);
     expect(res.attachments).not.toEqual("");
@@ -33,6 +35,7 @@ describe("activityPubGenerators", () => {
     const res: ActivityPub = apg.generatePerson(from);
     expect(res.name).not.toEqual("");
     expect(res.type).toEqual("Person");
+    expect(res.published).toMatch(/(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/);
   });
 
   it("generateImageAttachment works", () => {

--- a/src/generators/activityPubGenerators.ts
+++ b/src/generators/activityPubGenerators.ts
@@ -1,4 +1,4 @@
-import { ActivityPub, ActivityPubAttachment } from "../core/activityPub/activityPub";
+import { create, ActivityPub, ActivityPubAttachment } from "../core/activityPub/activityPub";
 import { HexString } from "../types/Strings";
 
 import { sample, sampleText } from "@dsnp/test-generators";
@@ -28,13 +28,13 @@ export const generateReply = (address: HexString, reply: string, inReplyTo: HexS
  * @param hasAttachment - the NoteAttachments for pictures and videos in this Note.
  */
 export const generateNote = (address: HexString, message: string, hasAttachment?: boolean): ActivityPub => {
-  return {
+  return create({
     attributedTo: address,
     "@context": "https://www.w3.org/ns/activitystreams",
     content: message,
     attachments: hasAttachment ? [generateImageAttachment()] : [],
     type: "Note",
-  };
+  });
 };
 
 /**
@@ -45,13 +45,13 @@ export const generateNote = (address: HexString, message: string, hasAttachment?
  */
 export const generatePerson = (address: HexString, name?: string): ActivityPub => {
   const newName = name ? name : [sample(PREFAB_FIRST_NAMES), sample(PREFAB_LAST_NAMES)].join(" ");
-  return {
+  return create({
     attributedTo: address,
     "@context": "https://www.w3.org/ns/activitystreams",
     name: newName,
     url: "",
     type: "Person",
-  };
+  });
 };
 
 /**


### PR DESCRIPTION
Problem
=======
Our activity pub generators do not include `published` timestamps, meaning they do not comply with our own spec.
[#178604714](https://www.pivotaltracker.com/story/show/178604714)

Solution
========
Update them to use the `activityPub.create` method which automatically sets `published`.