### PR TITLE
fix issues creating batch files in the browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@dsnp/contracts": "0.0.0-622366",
-        "@dsnp/parquetjs": "^1.1.0",
+        "@dsnp/parquetjs": "^1.1.1",
         "@dsnp/test-generators": "^0.1.0",
         "@ethersproject/abi": "^5.3.0",
         "ethers": "^5.3.0",
@@ -2128,9 +2128,9 @@
       "integrity": "sha512-WLl8AeV3TYH7NYdPLyRUser/qc9ELkS+qs/CMO71pJfJ5W2XGWQubccwIo0Y4diouM/XHtIf7veUeC/EWGBx3w=="
     },
     "node_modules/@dsnp/parquetjs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@dsnp/parquetjs/-/parquetjs-1.1.0.tgz",
-      "integrity": "sha512-3rPXqe6xxC90nbgQ2a+SWMiG2GBHlGnfsyyuuz43T8crjVZpfPeEQFz/1TpN09AjTRUpynLpMpCnOHGWBmKo5Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@dsnp/parquetjs/-/parquetjs-1.1.1.tgz",
+      "integrity": "sha512-CwjJ9q7jiQgkbiIB3HNiMYIF03CP819F3IRYgQpRklR5YUwWrw+Wz4oo5yTtcS7EaMov0IoRzv54eBl88XDZLQ==",
       "dependencies": {
         "@types/bson": "^4.0.3",
         "@types/long": "^4.0.1",
@@ -13159,9 +13159,9 @@
       "integrity": "sha512-WLl8AeV3TYH7NYdPLyRUser/qc9ELkS+qs/CMO71pJfJ5W2XGWQubccwIo0Y4diouM/XHtIf7veUeC/EWGBx3w=="
     },
     "@dsnp/parquetjs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@dsnp/parquetjs/-/parquetjs-1.1.0.tgz",
-      "integrity": "sha512-3rPXqe6xxC90nbgQ2a+SWMiG2GBHlGnfsyyuuz43T8crjVZpfPeEQFz/1TpN09AjTRUpynLpMpCnOHGWBmKo5Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@dsnp/parquetjs/-/parquetjs-1.1.1.tgz",
+      "integrity": "sha512-CwjJ9q7jiQgkbiIB3HNiMYIF03CP819F3IRYgQpRklR5YUwWrw+Wz4oo5yTtcS7EaMov0IoRzv54eBl88XDZLQ==",
       "requires": {
         "@types/bson": "^4.0.3",
         "@types/long": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   },
   "dependencies": {
     "@dsnp/contracts": "0.0.0-622366",
-    "@dsnp/parquetjs": "^1.1.0",
+    "@dsnp/parquetjs": "^1.1.1",
     "@dsnp/test-generators": "^0.1.0",
     "@ethersproject/abi": "^5.3.0",
     "ethers": "^5.3.0",

--- a/src/core/store/interface.ts
+++ b/src/core/store/interface.ts
@@ -6,8 +6,9 @@ export type Content = string | Buffer;
 export interface WriteStream {
   write(chunk: unknown, encoding?: string, callback?: (error: Error | null | undefined) => void): boolean;
   write(chunk: unknown, cb?: (error: Error | null | undefined) => void): boolean;
-  end(chunk: unknown, cb?: () => void): void;
-  end(chunk: unknown, encoding?: string, cb?: () => void): void;
+  end(cb?: () => void): void;
+  end(chunk?: unknown, cb?: () => void): void;
+  end(chunk?: unknown, encoding?: string, cb?: () => void): void;
 }
 
 /**


### PR DESCRIPTION
Problem
=======
There are a few issues that prevent generating parquetjs batch files correctly when running in the browser (probably on the server as well).

1. We wrap the incoming writeStream and overwrite its `write` method to hash outgoing data. We do not do this for the `end` method, so end doesn't get called on the underlying writeStream.
2. Our `WriteStream` interface has a 2 argument and 3 argument signature for `end`, but parquetjs is calling a 1 argument version (which exists on Nodejs's `Writable` interface).
3. We are not waiting for `appendRow` to complete.
4. We are specifying a version of parquetjs that does not support CommonJS or ESM builds in the browser.

Solution
========
This PR address all 4 issues
