### PR TITLE
Removed put from store interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 ### Changes
+- Removed put method from the store interface in favor of putStream everywhere
 - Renamed DSNPId to DSNPAnnouncementId to avoid confusion with DSNPUserId
 - Renamed uri -> url everywhere
 - Renamed sdk.subscribeToBatchAnnounceEvents -> sdk.subscribeToBatchPublications

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ setConfig({
 Storage solutions can be added so as long it matches the [StoreInterface](https://github.com/LibertyDSNP/sdk-ts/blob/main/src/core/store/interface.ts).
 ```typescript
 interface StoreInterface {
-  put: (targetPath: string, content: Content) => Promise<URL>;
   putStream: (targetPath: string, doWriteToStream: WriteStreamCallback) => Promise<URL>;
 }
 ```
@@ -120,7 +119,7 @@ Documentation is deployed on merge to main to GitHub Pages: https://libertydsnp.
     RPC_URL=http://localhost:8545
     TESTING_PRIVATE_KEY=ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     ```
-1. Replace the value of TESTING_PRIVATE_KEY with the value of `LOCAL_NETWORK_ACCOUNT_PRIVATE_KEY` in the .env from the contracts repo, or use what is in .github/workflows/main.yml. It may be same as above. 
+1. Replace the value of TESTING_PRIVATE_KEY with the value of `LOCAL_NETWORK_ACCOUNT_PRIVATE_KEY` in the .env from the contracts repo, or use what is in .github/workflows/main.yml. It may be same as above.
 1. Ensure that the contracts version you would like to use is the correct version. The version of the `@dsnp/contracts` package is specified in the `package.json`
 1. In the contracts repo run: `npm run hardhat -- node`
 1. In the contracts repo run: `npm run deploy:localhost`

--- a/src/content.test.ts
+++ b/src/content.test.ts
@@ -36,7 +36,7 @@ describe("content", () => {
           const keys = Object.keys(storeContents);
           expect(keys.length).toEqual(1);
 
-          expect(storeContents[keys[0]]).toMatch(
+          expect(storeContents[keys[0]].toString()).toMatch(
             /\{"@context":"https:\/\/www\.w3\.org\/ns\/activitystreams","attributedTo":"John Doe <johndoe@sample\.org>","content":"Lorem ipsum delor blah blah blah","name":"Lorem Ipsum","published":"[0-9TZ\-:.]+","type":"Note"\}/
           );
         });
@@ -160,7 +160,7 @@ describe("content", () => {
           const keys = Object.keys(storeContents);
           expect(keys.length).toEqual(1);
 
-          expect(storeContents[keys[0]]).toMatch(
+          expect(storeContents[keys[0]].toString()).toMatch(
             /\{"@context":"https:\/\/www\.w3\.org\/ns\/activitystreams","attributedTo":"John Doe <johndoe@sample\.org>","content":"Lorem ipsum delor blah blah blah","inReplyTo":"dsnp:\/\/0123456789ABCDEF\/0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF","name":"Lorem Ipsum","published":"[0-9TZ\-:.]+","type":"Note"\}/
           );
         });
@@ -372,7 +372,7 @@ describe("content", () => {
           const keys = Object.keys(storeContents);
           expect(keys.length).toEqual(1);
 
-          expect(storeContents[keys[0]]).toMatch(
+          expect(storeContents[keys[0]].toString()).toMatch(
             /\{"@context":"https:\/\/www\.w3\.org\/ns\/activitystreams","name":"Rose Karr","preferredUsername":"rosalinekarr","published":"[0-9TZ\-:.]+","type":"Person"\}/
           );
         });

--- a/src/content.ts
+++ b/src/content.ts
@@ -49,7 +49,10 @@ export const broadcast = async (
 
   const contentHash = keccak256(content);
   const store = requireGetStore(opts);
-  const url = await store.put(contentHash, content);
+  const url = await store.putStream(contentHash, async ({ write, end }) => {
+    write(content);
+    end();
+  });
 
   const announcement = announcements.createBroadcast(currentFromId, url.toString(), contentHash);
 
@@ -92,7 +95,10 @@ export const reply = async (
 
   const contentHash = keccak256(content);
   const store = requireGetStore(opts);
-  const url = await store.put(contentHash, content);
+  const url = await store.putStream(contentHash, async ({ write, end }) => {
+    write(content);
+    end();
+  });
 
   const announcement = announcements.createReply(currentFromId, url.toString(), contentHash, inReplyTo);
 
@@ -156,7 +162,10 @@ export const profile = async (
 
   const contentHash = keccak256(content);
   const store = requireGetStore(opts);
-  const url = await store.put(contentHash, content);
+  const url = await store.putStream(contentHash, async ({ write, end }) => {
+    write(content);
+    end();
+  });
 
   const announcement = announcements.createProfile(currentFromId, url.toString(), contentHash);
 

--- a/src/core/store/interface.ts
+++ b/src/core/store/interface.ts
@@ -34,16 +34,6 @@ export interface WriteStreamCallback {
  */
 export interface StoreInterface {
   /**
-   * put() takes a batch file to store with the chosen hosting solution and
-   * returns the URL of the file once stored.
-   *
-   * @param targetPath - The path to and name of file
-   * @param content - The file object to store on the chosen hosting solution
-   * @returns The URL of the hosted file
-   */
-  put: (targetPath: string, content: Content) => Promise<URL>;
-
-  /**
    * putStream() takes a pass-through stream to upload data to chosen hosting solution and
    * returns the URL of the file once stored.
    *

--- a/src/test/testStore.ts
+++ b/src/test/testStore.ts
@@ -7,11 +7,6 @@ export default class TestStore implements StoreInterface {
     this.store = {};
   }
 
-  async put(targetPath: string, content: Content): Promise<URL> {
-    this.store[targetPath] = content;
-    return new URL(`http://fakestore.org/${targetPath}`);
-  }
-
   async putStream(targetPath: string, callback: WriteStreamCallback): Promise<URL> {
     const buffers: Buffer[] = [];
     const writeStream = {
@@ -19,15 +14,26 @@ export default class TestStore implements StoreInterface {
         const [chunk, maybeCallback1, maybeCallback2] = args;
         if (typeof maybeCallback1 === "function") maybeCallback1(null);
         else if (typeof maybeCallback2 === "function") maybeCallback2(null);
-        buffers.push(chunk as Buffer);
+        if (typeof chunk === "string") {
+          buffers.push(Buffer.from(chunk));
+        } else {
+          buffers.push(chunk as Buffer);
+        }
+
         return false;
       },
       end: (...args: unknown[]) => {
         const [chunkOrFunction, maybeCallback] = args;
+        if (chunkOrFunction === undefined) return;
+
         if (typeof chunkOrFunction === "function") {
           chunkOrFunction(null);
         } else {
-          buffers.push(chunkOrFunction as Buffer);
+          if (typeof chunkOrFunction === "string") {
+            buffers.push(Buffer.from(chunkOrFunction));
+          } else {
+            buffers.push(chunkOrFunction as Buffer);
+          }
           if (typeof maybeCallback === "function") maybeCallback(null);
         }
       },


### PR DESCRIPTION
No story for this, just something we've been needing to do that I knocked out in my spare time.

Problem
=======
We didn't know how we'd use the store adapter when we first wrote the interface for it, and now we have redundant put methods, `put()` and `putStream()`, where only one is really needed.

Solution
=======
Remove `put()` from the store interface