### PR TITLE
feat(identity): add ability to retrieve logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 ### Added
 - sdk.createPublication
 - Ability to remove delegate
+- Ability to get DSNPAddDelegate logs
+- Ability to get DSNPRemoveDelegate logs
 ### Removed
 -
 ### Fixed

--- a/src/core/contracts/subscription.ts
+++ b/src/core/contracts/subscription.ts
@@ -18,7 +18,10 @@ export interface BatchPublicationCallbackArgs {
   fileHash: HexString;
 }
 
-interface ParsedLog {
+/**
+ * ParsedLog: interface for parsing log data
+ */
+export interface ParsedLog {
   fragment: ethers.utils.LogDescription;
   log: ethers.providers.Log;
 }


### PR DESCRIPTION
Add ability to retrieve logs for adding and
removing delegates:
  - DSNPRemoveDelegate
  - DSNPAddDelegate

This allows client to be able to resolve active
and inactive delegates.
