### PR TITLE
Add created_at field to GraphChange type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Ability to remove delegate
 - Ability to get DSNPAddDelegate logs
 - Ability to get DSNPRemoveDelegate logs
+- createdAt field to GraphChange announcement type, plus update to parquet schema. 
 ### Removed
 -
 ### Fixed

--- a/src/core/announcements/factories.ts
+++ b/src/core/announcements/factories.ts
@@ -1,6 +1,5 @@
 import { DSNPAnnouncementId, DSNPUserId } from "../identifiers";
 import { HexString } from "../../types/Strings";
-import { epochMillisecs } from "../utilities/time";
 
 /**
  * AnnouncementType: an enum representing different types of DSNP announcements
@@ -140,7 +139,7 @@ export const createFollowGraphChange = (fromId: DSNPUserId, followeeId: DSNPUser
   announcementType: AnnouncementType.GraphChange,
   changeType: DSNPGraphChangeType.Follow,
   objectId: followeeId,
-  createdAt: epochMillisecs(),
+  createdAt: Date.now(),
 });
 
 /**
@@ -156,7 +155,7 @@ export const createUnfollowGraphChange = (fromId: DSNPUserId, followeeId: DSNPUs
   announcementType: AnnouncementType.GraphChange,
   changeType: DSNPGraphChangeType.Unfollow,
   objectId: followeeId,
-  createdAt: epochMillisecs(),
+  createdAt: Date.now(),
 });
 
 /**

--- a/src/core/announcements/factories.ts
+++ b/src/core/announcements/factories.ts
@@ -1,5 +1,6 @@
 import { DSNPAnnouncementId, DSNPUserId } from "../identifiers";
 import { HexString } from "../../types/Strings";
+import { epochMillisecs } from "../utilities/time";
 
 /**
  * AnnouncementType: an enum representing different types of DSNP announcements
@@ -123,6 +124,7 @@ export enum DSNPGraphChangeType {
 export interface GraphChangeAnnouncement extends TypedAnnouncement<AnnouncementType.GraphChange> {
   changeType: DSNPGraphChangeType;
   objectId: DSNPUserId;
+  createdAt: number;
 }
 
 /**
@@ -138,6 +140,7 @@ export const createFollowGraphChange = (fromId: DSNPUserId, followeeId: DSNPUser
   announcementType: AnnouncementType.GraphChange,
   changeType: DSNPGraphChangeType.Follow,
   objectId: followeeId,
+  createdAt: epochMillisecs(),
 });
 
 /**
@@ -153,6 +156,7 @@ export const createUnfollowGraphChange = (fromId: DSNPUserId, followeeId: DSNPUs
   announcementType: AnnouncementType.GraphChange,
   changeType: DSNPGraphChangeType.Unfollow,
   objectId: followeeId,
+  createdAt: epochMillisecs(),
 });
 
 /**

--- a/src/core/announcements/validation.ts
+++ b/src/core/announcements/validation.ts
@@ -61,7 +61,7 @@ export const isGraphChangeAnnouncement = (obj: unknown): obj is GraphChangeAnnou
   if (!isDSNPUserId(obj["fromId"])) return false;
   if (!isGraphChangeType(obj["changeType"])) return false;
   if (!isDSNPUserId(obj["objectId"])) return false;
-
+  if (!isNumber(obj["createdAt"])) return false;
   return true;
 };
 

--- a/src/core/batch/parquetSchema.test.ts
+++ b/src/core/batch/parquetSchema.test.ts
@@ -10,6 +10,7 @@ describe("#getSchemaFor", () => {
       announcementType: { type: "INT32" },
       fromId: { type: "BYTE_ARRAY" },
       signature: { type: "BYTE_ARRAY" },
+      createdAt: { type: "INT64" },
     });
   });
 

--- a/src/core/batch/parquetSchema.ts
+++ b/src/core/batch/parquetSchema.ts
@@ -72,6 +72,7 @@ export const GraphChangeSchema = {
   fromId: { type: "BYTE_ARRAY" },
   changeType: { type: "INT32" },
   signature: { type: "BYTE_ARRAY" },
+  createdAt: { type: "INT64" },
 };
 
 /**

--- a/src/core/utilities/time.ts
+++ b/src/core/utilities/time.ts
@@ -1,3 +1,0 @@
-export const epochMillisecs = (): number => {
-  return Date.now() * 1000;
-};

--- a/src/core/utilities/time.ts
+++ b/src/core/utilities/time.ts
@@ -1,0 +1,3 @@
+export const epochMillisecs = (): number => {
+  return Date.now() * 1000;
+};


### PR DESCRIPTION
Problem
=======
Add created_at field to GraphChange type.
[Fixes #178607496](https://www.pivotaltracker.com/story/show/178607496)

Double Checks:
---------------
- [x] Did you update the changelog?
- [x] Are new methods in the right module?

Change summary:
---------------
* Add createdAt field to GraphChange announcement interface
* Add the type check to the GraphChange validator

Steps to Verify:
----------------
1. CI should pass.
