### PR TITLE
update readme with contract addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,23 @@ Documentation is deployed on merge to main to GitHub Pages: https://libertydsnp.
   - Custom Loaded Jest expect matchers like `expect(tx).transactionRejectsWith("message")`
 - test/generators
   - Test Data Generators and fixtures
+
+
+### Testnet
+We are currently running 2 POA nodes for our Testnet
+Tesnet Authority nodes are:
+
+- node0.testnet.dsnp.org
+- node1.testnet.dsnp.org
+
+#### Contracts are located at the following addresses:
+
+Migrations contract: 0xe7a6467113c2B7f09Aad3b99C30811718A114013
+Publisher contract: 0xdBA8e92706e48bbFDe1A8496710d4e85d3388E71
+Identity contract: 0xB708186004dAC4019417fa8deF9E8F49a55103b1
+Registry contract: 0xDcc457296d9790C52B6746cD45AFaaD18b7FfEfa
+IdentityCloneFactory factory: 0x31C3fDb70078FD1d64D51ecA713bCdb2f4212E74
+Beacon contract: 0x233FfDa2cEd4579B07bbc5e95bDe7f540A2DFd5a
+Beacon Factory: 0x26b21a1E90b86c779D9a1d31cD09F5cd8C7c8f1d
+
+Contract source code is located [here](https://github.com/LibertyDSNP/contracts)


### PR DESCRIPTION
Problem
=======
We need to list where our tesnet nodes live and what the addresses are for the deployed contracts so that people can access them. 

Solution
========
Update README to show addresses of both testnet nodes and contracts 
