### PR TITLE
check for pastLogs.length before continuing in subscribeToBatchPublications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## Unreleased
 ### Changes
+- Fix length check bug in `subscribeToBatchPublications`
 - Updated announcement types to include createdAt type
 - Updated announcement factories to include optional createdAt param
 - Updated various types to specify DSNP ids instead of string
 - Updated various types to specify HexString instead of string
 - Updated all instances of keccak256 to use hash utilities instead
-- Added hash() and getHashGenerator() utilitiy functions
+- Added hash() and getHashGenerator() utility functions
 - Moved "requireGet" config methods back into the SDK core
 - Removed put method from the store interface in favor of putStream everywhere
 - Updated activityContent types to match spec

--- a/src/core/contracts/subscription.test.ts
+++ b/src/core/contracts/subscription.test.ts
@@ -1,6 +1,6 @@
 import { requireGetProvider } from "../config";
 import { publish, Publication, dsnpBatchFilter } from "./publisher";
-import { subscribeToBatchPublications, BatchPublicationCallbackArgs } from "./subscription";
+import { subscribeToBatchPublications, BatchPublicationCallbackArgs, BatchFilterOptions } from "./subscription";
 import { setupSnapshot } from "../../test/hardhatRPC";
 import { setupConfig } from "../../test/sdkTestConfig";
 import { checkNumberOfFunctionCalls } from "../../test/utilities";
@@ -63,6 +63,23 @@ describe("subscription", () => {
       await removeListener();
       const filter = await dsnpBatchFilter();
       expect(provider.listeners(filter).length).toEqual(0);
+    });
+    describe("when a filter is provided", () => {
+      const filterOptions: BatchFilterOptions = {
+        announcementType: 2,
+        fromBlock: 0,
+      };
+
+      it("does not fail if there are no past logs", async () => {
+        const provider = requireGetProvider();
+        const mock = jest.fn();
+
+        const removeListener = await subscribeToBatchPublications(mock, filterOptions);
+        expect(mock).not.toHaveBeenCalled();
+        await removeListener();
+        const filter = await dsnpBatchFilter();
+        expect(provider.listeners(filter).length).toEqual(0);
+      });
     });
 
     describe("when listener is removed", () => {

--- a/src/core/contracts/subscription.ts
+++ b/src/core/contracts/subscription.ts
@@ -70,18 +70,20 @@ export const subscribeToBatchPublications = async (
 
   if (useQueue) {
     pastLogs = await getPastLogs(provider, { ...batchFilter, fromBlock: filter?.fromBlock });
-    maxBlockNumberForPastLogs = pastLogs[pastLogs.length - 1].blockNumber;
 
-    while (pastLogs.length > 0) {
-      const batchItem = pastLogs.shift();
-      if (batchItem) doReceivePublication(batchItem);
+    if (pastLogs.length) {
+      maxBlockNumberForPastLogs = pastLogs[pastLogs.length - 1].blockNumber;
+
+      while (pastLogs.length > 0) {
+        const batchItem = pastLogs.shift();
+        if (batchItem) doReceivePublication(batchItem);
+      }
+
+      while (currentLogQueue.length > 0) {
+        const batchItem = currentLogQueue.shift();
+        if (batchItem && batchItem.blockNumber > maxBlockNumberForPastLogs) doReceivePublication(batchItem);
+      }
     }
-
-    while (currentLogQueue.length > 0) {
-      const batchItem = currentLogQueue.shift();
-      if (batchItem && batchItem.blockNumber > maxBlockNumberForPastLogs) doReceivePublication(batchItem);
-    }
-
     useQueue = false;
   }
 


### PR DESCRIPTION
Problem
=======
In `subscribeToBatchPublications`, we needed to check the length of pastLogs before trying to look at the blockNumber of one of its elements.
[Fixes #179033826](https://www.pivotaltracker.com/story/show/179033826)

Solution
========
Do the length check
Add a regression test that shows the red/green behavior

Double Checks:
---------------
- [x] Did you update the changelog?

Steps to Verify:
----------------
1. The test passes
1. For extra credit you can build sdk and make example-client use it, then launch a hardhat localnet with no logs or anything, and login to the example client.  You should not see the error message as shown in the Tracker story.
