### PR TITLE
Bugs/value required on activity content hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dsnp/sdk",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dsnp/sdk",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dsnp/contracts": "1.0.0",

--- a/src/core/activityContent/validation.test.ts
+++ b/src/core/activityContent/validation.test.ts
@@ -131,6 +131,29 @@ describe("activity content validations", () => {
           },
         ],
       },
+      "a note with an audio attachement missing a hash value": {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        type: "Note",
+        content: "Feel like I've heard this before!",
+        mediaType: "text/plain",
+        attachment: [
+          {
+            type: "Audio",
+            url: [
+              {
+                type: "Link",
+                href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
+                mediaType: "audio/ogg",
+                hash: [
+                  {
+                    algorithm: "keccak256",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
       "a note with an image attachement missing a mediaType": {
         "@context": "https://www.w3.org/ns/activitystreams",
         type: "Note",

--- a/src/core/activityContent/validation.ts
+++ b/src/core/activityContent/validation.ts
@@ -78,6 +78,7 @@ const isActivityContentVideoLink = (obj: unknown): obj is ActivityContentVideoLi
 const isActivityContentHash = (obj: unknown): obj is ActivityContentHash => {
   if (!isRecord(obj)) return false;
   if (!isString(obj["algorithm"])) return false;
+  if (!isString(obj["value"])) return false;
 
   return true;
 };


### PR DESCRIPTION
Problem
=======
No task for this, just a quick fix following spec change

Solution
========
Updated `ActivityContentHash` validators to require `"value"` field.
