### PR TITLE
Not all ethereum nodes will return a message with why something reverted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Changes
+- Updated registry.resolveRegistration to support not found cases for nodes that do not return a failure reason.
 
 ## [2.0.0] - 2021-08-02
 ### Changes

--- a/src/core/contracts/registry.ts
+++ b/src/core/contracts/registry.ts
@@ -26,8 +26,6 @@ export type Handle = string;
  * @throws {@link MissingProviderConfigError}
  * Thrown if the provider is not configured.
  * @throws {@link MissingContractAddressError}
- * Thrown if the registration contract address cannot be found.
- * @throws a VMError if contract fails
  * @param handle - String handle to resolve
  * @param opts - (optional) any config overrides.
  * @returns A Registration object for the user or null if not found
@@ -44,7 +42,7 @@ export const resolveRegistration = async (handle: Handle, opts?: ConfigOpts): Pr
   } catch (e) {
     const error = <VmError>e;
     const vmError = getVmError(error);
-    if (vmError?.includes("Handle does not exist")) {
+    if (vmError) {
       return null;
     }
     throw e;


### PR DESCRIPTION
Problem
=======
OpenEthereum can be configured to not return the revert error message which tripped up the resolveRegistration code testing for it.

Solution
========
Removed the check for the error message

with @amparks100 

Double Checks:
---------------
- [x] Did you update the changelog?
- [x] Any new modules need to be exported?
- [x] Are new methods in the right module?
- [x] Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [x] Do you have good documentation on exported methods?

Change summary:
---------------
* Updated registry.resolveRegistration to support not found cases for nodes that do not return a failure reason.
