### PR TITLE
No longer using destructuring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 ### Changes
 - Updated registry.resolveRegistration to support not found cases for nodes that do not return a failure reason.
 
+## [2.0.1] - TBD
+### Fixed
+- no longer using destructuring for methods that result in a `store.putStream` call. 
+
 ## [2.0.0] - 2021-08-02
 ### Changes
 - Updated npm dependencies

--- a/src/content.ts
+++ b/src/content.ts
@@ -49,9 +49,9 @@ export const broadcast = async (
 
   const contentHash = hash(content);
   const store = requireGetStore(opts);
-  const url = await store.putStream(contentHash, async ({ write, end }) => {
-    write(content);
-    end();
+  const url = await store.putStream(contentHash, async (writeStream) => {
+    writeStream.write(content);
+    writeStream.end();
   });
 
   const announcement = createBroadcast(currentFromURI, url.toString(), contentHash);
@@ -94,9 +94,9 @@ export const reply = async (
 
   const contentHash = hash(content);
   const store = requireGetStore(opts);
-  const url = await store.putStream(contentHash, async ({ write, end }) => {
-    write(content);
-    end();
+  const url = await store.putStream(contentHash, async (writeStream) => {
+    writeStream.write(content);
+    writeStream.end();
   });
 
   const announcement = createReply(currentFromURI, url.toString(), contentHash, inReplyTo);
@@ -160,9 +160,9 @@ export const profile = async (
 
   const contentHash = hash(content);
   const store = requireGetStore(opts);
-  const url = await store.putStream(contentHash, async ({ write, end }) => {
-    write(content);
-    end();
+  const url = await store.putStream(contentHash, async (writeStream) => {
+    writeStream.write(content);
+    writeStream.end();
   });
 
   const announcement = createProfile(currentFromURI, url.toString(), contentHash);


### PR DESCRIPTION
Now not using destructuring because of, what I can only assume, is
"this" style issues. Basically a private member _writableState will be
undefined. Using the object directly fixes that issue

Problem
=======
using destructuring causes FileStreams to have undefined members.
[Pivotal issue](https://www.pivotaltracker.com/story/show/179110784)

Solution
========
No longer use destructuring and call the WriteStream methods .write and .end directly

Double Checks:
---------------
- [] Did you update the changelog?
- [x] Any new modules need to be exported?
- [x] Are new methods in the right module?
- [x] Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [x] Do you have good documentation on exported methods?

Change summary:
---------------
No longer using destructuring when working with the WriteStream in the putStream callback flow

Steps to Verify:
----------------
A bit tough as I needed to consume the library in another app to make sure it worked.
