### PR TITLE
Update the published datetime regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Changes
 - Updated registry.resolveRegistration to support not found cases for nodes that do not return a failure reason.
+- Updated the Activity Content Published field validation regex to support fractional seconds
 
 ## [2.0.1] - TBD
 ### Fixed

--- a/src/core/activityContent/validation.test.ts
+++ b/src/core/activityContent/validation.test.ts
@@ -230,7 +230,7 @@ describe("activity content validations", () => {
         "@context": "https://www.w3.org/ns/activitystreams",
         type: "Profile",
         name: "jaboukie",
-        published: "2000-01-01T00:00:00+00:00",
+        published: "2000-01-01T00:00:00.000+00:00",
       },
       "a profile object with icon": {
         "@context": "https://www.w3.org/ns/activitystreams",

--- a/src/core/activityContent/validation.ts
+++ b/src/core/activityContent/validation.ts
@@ -18,7 +18,14 @@ import {
 import { isDSNPUserId } from "../identifiers";
 import { isRecord, isString, isNumber, isArrayOfType } from "../utilities/validation";
 
-const ISO8601_REGEX = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})([+-](\d{2}):(\d{2}))?$/;
+/**
+ * Regex for ISO 8601 / XML Schema Dates
+ * - T separation
+ * - Required Time
+ * - Supports fractional seconds
+ * - Z or hour minute offset
+ */
+const ISO8601_REGEX = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d{1,})?(Z|[+-][01][0-9]:[0-5][0-9])?$/;
 const HREF_REGEX = /^https?:\/\/.+/;
 const DURATION_REGEX = /^-?P[0-9]+Y?([0-9]+M)?([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+(\.[0-9]+)?S)?)?$/;
 const HASH_REGEX = /^0x[0-9A-Fa-f]{64}$/;


### PR DESCRIPTION
Problem
=======
Published regex did not support fractional seconds or other timezone offset options
[#179076218](https://www.pivotaltracker.com/story/show/179076218)

Solution
========
Updated the regex

Double Checks:
---------------
- [x] Did you update the changelog?
- [x] Any new modules need to be exported?
- [x] Are new methods in the right module?
- [x] Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [x] Do you have good documentation on exported methods?