### PR TITLE
sdk.createRegistration correctly returns a DSNPUserURI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Updated the Activity Content Published field validation regex to support fractional seconds
 - Updated @dsnp/contracts to v1.0.1
 - Updated minor dependencies
+### Fixed
+- sdk.createRegistration was incorrectly returning a DSNP User Id instead of a DSNP User URI
 
 ## [2.0.1] - TBD
 ### Fixed

--- a/src/handles.test.ts
+++ b/src/handles.test.ts
@@ -112,6 +112,7 @@ describe("handles", () => {
       const id = convertDSNPUserIdOrURIToBigNumber(dsnpUserURI);
 
       expect(id.toNumber()).toBeGreaterThan(999);
+      expect(dsnpUserURI.substr(0, 9)).toEqual("dsnp://0x");
     });
   });
 });

--- a/src/handles.ts
+++ b/src/handles.ts
@@ -2,7 +2,7 @@ import * as config from "./core/config";
 import { Registration, Handle, getDSNPRegistryUpdateEvents, resolveRegistration } from "./core/contracts/registry";
 import { createAndRegisterBeaconProxy } from "./core/contracts/identity";
 import { findEvent } from "./core/contracts/contract";
-import { convertBigNumberToDSNPUserId, DSNPUserURI } from "./core/identifiers";
+import { convertBigNumberToDSNPUserURI, DSNPUserURI } from "./core/identifiers";
 import { HexString } from "./types/Strings";
 
 /**
@@ -18,7 +18,7 @@ import { HexString } from "./types/Strings";
  * @param addr - public key address that will be used to control identity delegate
  * @param handle - name of identity (must be globally unique)
  * @param opts - Optional. Configuration overrides, such as from address, if any
- * @returns id of identity created
+ * @returns DSNP User URI of identity created
  */
 export const createRegistration = async (
   addr: HexString,
@@ -29,7 +29,7 @@ export const createRegistration = async (
   const receipt = await txn.wait(1);
 
   const registerEvent = findEvent("DSNPRegistryUpdate", receipt.logs);
-  return convertBigNumberToDSNPUserId(registerEvent.args[0]);
+  return convertBigNumberToDSNPUserURI(registerEvent.args[0]);
 };
 
 /**


### PR DESCRIPTION
Problem
=======
sdk.createRegistration said it was returning a DSNPUserURI, but it was not.

Solution
========
Made it return a DSNPUserURI

Double Checks:
---------------
- [x] Did you update the changelog?
- [x] Any new modules need to be exported?
- [x] Are new methods in the right module?
- [x] Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [x] Do you have good documentation on exported methods?
