### PR TITLE
v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,17 @@
 
 ## Unreleased
 ### Changes
+
+## [2.0.1] - 2021-08-04
+### Changes
 - Updated registry.resolveRegistration to support not found cases for nodes that do not return a failure reason.
 - Updated the Activity Content Published field validation regex to support fractional seconds
 - Updated @dsnp/contracts to v1.0.1
 - Updated minor dependencies
-### Fixed
-- sdk.createRegistration was incorrectly returning a DSNP User Id instead of a DSNP User URI
 
-## [2.0.1] - TBD
 ### Fixed
-- no longer using destructuring for methods that result in a `store.putStream` call. 
+- no longer using destructuring for methods that result in a `store.putStream` call.
+- sdk.createRegistration was incorrectly returning a DSNP User Id instead of a DSNP User URI
 
 ## [2.0.0] - 2021-08-02
 ### Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dsnp/sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dsnp/sdk",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dsnp/contracts": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsnp/sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "SDK Library for the DSNP",
   "type": "commonjs",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
## [2.0.1] - 2021-08-04
### Changes
- Updated registry.resolveRegistration to support not found cases for nodes that do not return a failure reason.
- Updated the Activity Content Published field validation regex to support fractional seconds
- Updated @dsnp/contracts to v1.0.1
- Updated minor dependencies

### Fixed
- no longer using destructuring for methods that result in a `store.putStream` call.
- sdk.createRegistration was incorrectly returning a DSNP User Id instead of a DSNP User URI