### PR TITLE
dsnpBatchFilter does not require any provider or signer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Unreleased
 ### Added
-- Ability to filter registr update events based on start and end block
+- Ability to filter registry update events based on start and end block
 
 ### Changes
 - Renamed BatchPublicationCallbackArgs -> BatchPublicationLogData
+- Updated subscribeToBatchPublications to not need a signer
+- sdk.core.contracts.publisher.dsnpBatchFilter is no longer async
 
 ## [2.0.1] - 2021-08-04
 ### Changes

--- a/src/core/contracts/publisher.test.ts
+++ b/src/core/contracts/publisher.test.ts
@@ -26,7 +26,16 @@ describe("#batch", () => {
     );
   });
 
-  it("can return the topic", () => {
-    expect(dsnpBatchFilter().topics).toEqual(["0xe63a4904ccacc079f71e52aad2cf99c00a7d4963566562a94d7c07610f1df576"]);
+  describe("dsnpBatchFilter", () => {
+    it("can return the topic", () => {
+      expect(dsnpBatchFilter().topics).toEqual(["0xe63a4904ccacc079f71e52aad2cf99c00a7d4963566562a94d7c07610f1df576"]);
+    });
+
+    it("can return the topics with a type filter", () => {
+      expect(dsnpBatchFilter(1).topics).toEqual([
+        "0xe63a4904ccacc079f71e52aad2cf99c00a7d4963566562a94d7c07610f1df576",
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+      ]);
+    });
   });
 });

--- a/src/core/contracts/publisher.test.ts
+++ b/src/core/contracts/publisher.test.ts
@@ -1,4 +1,4 @@
-import { publish, Publication } from "./publisher";
+import { publish, Publication, dsnpBatchFilter } from "./publisher";
 import { hash } from "../utilities";
 import { setupConfig } from "../../test/sdkTestConfig";
 import { setupSnapshot } from "../../test/hardhatRPC";
@@ -24,5 +24,9 @@ describe("#batch", () => {
     expect(logs[0].data).toEqual(
       "0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb65800000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000018687474703a2f2f7777772e74657374636f6e73742e636f6d0000000000000000"
     );
+  });
+
+  it("can return the topic", () => {
+    expect(dsnpBatchFilter().topics).toEqual(["0xe63a4904ccacc079f71e52aad2cf99c00a7d4963566562a94d7c07610f1df576"]);
   });
 });

--- a/src/core/contracts/publisher.ts
+++ b/src/core/contracts/publisher.ts
@@ -3,6 +3,7 @@ import { ConfigOpts, requireGetProvider, requireGetSigner } from "../config";
 import { HexString } from "../../types/Strings";
 import { Publisher, Publisher__factory } from "../../types/typechain";
 import { getContractAddress } from "./contract";
+import { AnnouncementType } from "../announcements";
 
 const CONTRACT_NAME = "Publisher";
 
@@ -33,14 +34,19 @@ export const publish = async (publications: Publication[]): Promise<ContractTran
 /**
  * Retrieves event filter for DSNPBatch event
  *
+ * @param announcementType - DSNP Announcement Type Filter
  * @returns DSNPBatch event filter
  */
-export const dsnpBatchFilter = (): EventFilter => {
+export const dsnpBatchFilter = (announcementType?: AnnouncementType): EventFilter => {
   const publisherInterface = Publisher__factory.createInterface();
   const topic = publisherInterface.getEventTopic(
     publisherInterface.events["DSNPBatchPublication(int16,bytes32,string)"]
   );
-  return { topics: [topic] };
+  const topics = [topic];
+  if (announcementType) {
+    topics.push("0x" + announcementType.toString(16).padStart(64, "0"));
+  }
+  return { topics };
 };
 
 const getPublisherContract = async (opts?: ConfigOpts): Promise<Publisher> => {

--- a/src/core/contracts/publisher.ts
+++ b/src/core/contracts/publisher.ts
@@ -33,17 +33,14 @@ export const publish = async (publications: Publication[]): Promise<ContractTran
 /**
  * Retrieves event filter for DSNPBatch event
  *
- * @throws {@link MissingSignerConfigError}
- * Thrown if the signer is not configured.
- * @throws {@link MissingProviderConfigError}
- * Thrown if the provider is not configured.
- * @throws {@link MissingContractAddressError}
- * Thrown if the batch contract address cannot be found.
  * @returns DSNPBatch event filter
  */
-export const dsnpBatchFilter = async (): Promise<EventFilter> => {
-  const contract = await getPublisherContract();
-  return contract.filters.DSNPBatchPublication();
+export const dsnpBatchFilter = (): EventFilter => {
+  const publisherInterface = Publisher__factory.createInterface();
+  const topic = publisherInterface.getEventTopic(
+    publisherInterface.events["DSNPBatchPublication(int16,bytes32,string)"]
+  );
+  return { topics: [topic] };
 };
 
 const getPublisherContract = async (opts?: ConfigOpts): Promise<Publisher> => {

--- a/src/core/contracts/subscription.ts
+++ b/src/core/contracts/subscription.ts
@@ -58,7 +58,7 @@ export const subscribeToBatchPublications = async (
 ): Promise<() => void> => {
   let pastLogs: BatchPublicationLogData[] = [];
   const currentLogQueue: BatchPublicationLogData[] = [];
-  const batchFilter: ethers.EventFilter = await dsnpBatchFilter();
+  const batchFilter: ethers.EventFilter = dsnpBatchFilter();
   const batchFilterWithOptions = filter ? createFilter(batchFilter, filter) : batchFilter;
 
   const provider = requireGetProvider();

--- a/src/core/contracts/subscription.ts
+++ b/src/core/contracts/subscription.ts
@@ -58,14 +58,13 @@ export const subscribeToBatchPublications = async (
 ): Promise<() => void> => {
   let pastLogs: BatchPublicationLogData[] = [];
   const currentLogQueue: BatchPublicationLogData[] = [];
-  const batchFilter: ethers.EventFilter = dsnpBatchFilter();
-  const batchFilterWithOptions = filter ? createFilter(batchFilter, filter) : batchFilter;
+  const batchFilter: ethers.EventFilter = dsnpBatchFilter(filter?.announcementType);
 
   const provider = requireGetProvider();
   let maxBlockNumberForPastLogs = filter?.fromBlock || 0;
   let useQueue = filter?.fromBlock != undefined;
 
-  provider.on(batchFilterWithOptions, (log: ethers.providers.Log) => {
+  provider.on(batchFilter, (log: ethers.providers.Log) => {
     const logItem = decodeLogsForBatchPublication([log])[0];
 
     if (useQueue) {
@@ -95,23 +94,8 @@ export const subscribeToBatchPublications = async (
   }
 
   return () => {
-    provider.off(batchFilterWithOptions);
+    provider.off(batchFilter);
   };
-};
-
-const createFilter = (batchFilter: ethers.EventFilter, filterOptions: BatchFilterOptions) => {
-  const topics = batchFilter.topics ? batchFilter.topics : [];
-  const announcementTypeTopic = filterOptions?.announcementType
-    ? "0x" + filterOptions.announcementType.toString(16).padStart(64, "0")
-    : null;
-  if (announcementTypeTopic) {
-    topics.push(announcementTypeTopic);
-  }
-
-  const finalFilter: ethers.providers.EventType = {
-    topics: topics,
-  };
-  return finalFilter;
 };
 
 const getPastLogs = async (provider: ethers.providers.Provider, filter: Filter): Promise<BatchPublicationLogData[]> => {


### PR DESCRIPTION
Problem
=======
The announcements API has a single method to get the contract for batch and subscribe operations. This method requires a signer to connect. This is necessary for the batch operation. The subscription (specifically the dsnpBatchFilter) is read only, so should be capable of running with just a provider.
[#178901784](https://www.pivotaltracker.com/story/show/178901784)

Solution
========
Used the interface instead of the contract to get the needed topic data.

Double Checks:
---------------
- [x] Did you update the changelog?
- [x] Any new modules need to be exported?
- [x] Are new methods in the right module?
- [x] Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [x] Do you have good documentation on exported methods?

Change summary:
---------------
* Switched dsnpBatchFilter to use the interface instead of the contract to create the filter.
