### PR TITLE
Export core identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Added
 - Ability to filter registry update events based on start and end block
+- Exported sdk.core.identifiers
 
 ### Changes
 - Renamed BatchPublicationCallbackArgs -> BatchPublicationLogData

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -29,3 +29,6 @@ export const store = storeImport;
 
 import * as utilitiesImport from "./utilities";
 export const utilities = utilitiesImport;
+
+import * as identifiersImport from "./identifiers";
+export const identifiers = identifiersImport;

--- a/src/test/importTest/index.ts
+++ b/src/test/importTest/index.ts
@@ -2,6 +2,7 @@ import assert from "assert";
 
 import sdk from "@dsnp/sdk";
 import { generators } from "@dsnp/sdk";
+import { buildDSNPAnnouncementURI } from "@dsnp/sdk/core/identifiers";
 import { subscribeToBatchPublications } from "@dsnp/sdk/core/contracts/subscription";
 
 Object.entries({
@@ -10,6 +11,7 @@ Object.entries({
   generators,
   dsnpGenerators: generators.dsnp.generateBroadcast,
   contractSubscription: subscribeToBatchPublications,
+  buildDSNPAnnouncementURI: buildDSNPAnnouncementURI,
 }).forEach(([key, value]) => {
   assert.notStrictEqual(value, undefined, `Was unable to import ${key}`);
 });


### PR DESCRIPTION
Problem
=======
sdk.core.identifiers were not exported, but they should be for people to use them

Solution
========
Added it to the exports

Double Checks:
---------------
- [x] Did you update the changelog?
- [x] Any new modules need to be exported?
- [x] Are new methods in the right module?
- [x] Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [x] Do you have good documentation on exported methods?
