### PR TITLE
Bugs/better errors #179106793

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Unreleased
-Fix bug in `getRegistrationsByWalletAddress` by normalizing address to checksum version 
+- Reworked ActivityContent validations to log or throw informative errors when an ActvityContent is invalid. 
+- Fixed a bug in DURATION_REGEX.
+- Fix bug in `getRegistrationsByWalletAddress` by normalizing address to checksum version 
 
 ## [2.0.2] - 2021-08-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## Unreleased
+- Major rework of ActivityContent validations to log or throw informative errors when an ActvityContent is invalid, with a couple of other changes:
+  - An array of locations is no longer allowed; this will invalidate an attachment. 
+  - Attachments MUST pass a minimal type check before further processing. For example if even one of its Link url hashes is _malformed_, it fails validation.
+  - If an attachment passes a type check, but it fails to meet requirements for what is supported by DSNP, it also fails validation. HOWEVER, attachments can have multiple Link URLs; only one needs to be supported by DSNP to be considered a valid attachment. See code documentation for details.
+  - If there is more than one attachment, but at least one is valid, it's considered a valid ActivityContent.
+  - New exported function for retrieving an array of valid attachments for an ActivityContent: `requireGetSupportedContentAttachments`  Please see code documentation for details. 
+  - Note on naming convention: anything beginning with 'require' will throw when failing the indicated action or validation. For example `requireGetSupportedContentAttachments` throws an error if there are attachments but none are valid.
+- Fixed a bug in duration validation.
 - Reworked ActivityContent validations to log or throw informative errors when an ActvityContent is invalid. 
 - Fixed a bug in DURATION_REGEX.
 - Fix bug in `getRegistrationsByWalletAddress` by normalizing address to checksum version 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - If there is more than one attachment, but at least one is valid, it's considered a valid ActivityContent.
   - New exported function for retrieving an array of valid attachments for an ActivityContent: `requireGetSupportedContentAttachments`  Please see code documentation for details. 
   - Note on naming convention: anything beginning with 'require' will throw when failing the indicated action or validation. For example `requireGetSupportedContentAttachments` throws an error if there are attachments but none are valid.
+  - If you wish to simply check for type validity without having to catch errors, use `isActivityContentNoteType` and `isActivityContentProfileType` 
 - Fixed a bug in duration validation.
 - Reworked ActivityContent validations to log or throw informative errors when an ActvityContent is invalid. 
 - Fixed a bug in DURATION_REGEX.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Fix bug in `getRegistrationsByWalletAddress` by normalizing address to checksum 
 
 ## [2.0.1] - 2021-08-04
 ### Changes
+- Reworked ActivityContent validations to log or throw informative errors when an ActvityContent is invalid. Fixed a bug in DURATION_REGEX.
 - Updated registry.resolveRegistration to support not found cases for nodes that do not return a failure reason.
 - Updated the Activity Content Published field validation regex to support fractional seconds
 - Updated @dsnp/contracts to v1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   - Note on naming convention: anything beginning with 'require' will throw when failing the indicated action or validation. For example `requireGetSupportedContentAttachments` throws an error if there are attachments but none are valid.
   - If you wish to simply check for type validity without having to catch errors, use `isActivityContentNoteType` and `isActivityContentProfileType` 
 - Fixed a bug in duration validation.
-- Reworked ActivityContent validations to log or throw informative errors when an ActvityContent is invalid. 
+- Reworked ActivityContent validations to log or throw informative errors when an ActivityContent is invalid. 
 - Fixed a bug in DURATION_REGEX.
 - Fix bug in `getRegistrationsByWalletAddress` by normalizing address to checksum version 
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,7 +1,7 @@
 import { requireGetCurrentFromURI, requireGetStore, ConfigOpts } from "./core/config";
 import {
   requireValidActivityContentNote,
-  isValidActivityContentProfile,
+  requireValidActivityContentProfile,
   serialize,
   ActivityContentNote,
   ActivityContentProfile,
@@ -157,7 +157,7 @@ export const profile = async (
   contentObject: ActivityContentProfile,
   opts?: ConfigOpts
 ): Promise<SignedProfileAnnouncement> => {
-  if (!isValidActivityContentProfile(contentObject)) throw new InvalidActivityContentError();
+  if (!requireValidActivityContentProfile(contentObject)) throw new InvalidActivityContentError();
   const content = serialize(contentObject);
 
   const currentFromURI = requireGetCurrentFromURI(opts);

--- a/src/content.ts
+++ b/src/content.ts
@@ -5,7 +5,6 @@ import {
   serialize,
   ActivityContentNote,
   ActivityContentProfile,
-  InvalidActivityContentError,
 } from "./core/activityContent";
 import {
   createBroadcast,

--- a/src/content.ts
+++ b/src/content.ts
@@ -157,7 +157,7 @@ export const profile = async (
   contentObject: ActivityContentProfile,
   opts?: ConfigOpts
 ): Promise<SignedProfileAnnouncement> => {
-  if (!requireValidActivityContentProfile(contentObject)) throw new InvalidActivityContentError();
+  requireValidActivityContentProfile(contentObject);
   const content = serialize(contentObject);
 
   const currentFromURI = requireGetCurrentFromURI(opts);

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,6 +1,6 @@
 import { requireGetCurrentFromURI, requireGetStore, ConfigOpts } from "./core/config";
 import {
-  isValidActivityContentNote,
+  requireValidActivityContentNote,
   isValidActivityContentProfile,
   serialize,
   ActivityContentNote,
@@ -46,7 +46,7 @@ export const broadcast = async (
   contentObject: ActivityContentNote,
   opts?: ConfigOpts
 ): Promise<SignedBroadcastAnnouncement> => {
-  if (!isValidActivityContentNote(contentObject)) throw new InvalidActivityContentError();
+  requireValidActivityContentNote(contentObject);
   const content = serialize(contentObject);
 
   const currentFromURI = requireGetCurrentFromURI(opts);
@@ -91,7 +91,7 @@ export const reply = async (
 ): Promise<SignedReplyAnnouncement> => {
   if (!isDSNPAnnouncementURI(inReplyTo)) throw new InvalidAnnouncementUriError(inReplyTo);
 
-  if (!isValidActivityContentNote(contentObject)) throw new InvalidActivityContentError();
+  requireValidActivityContentNote(contentObject);
   const content = serialize(contentObject);
 
   const currentFromURI = requireGetCurrentFromURI(opts);

--- a/src/core/activityContent/errors.ts
+++ b/src/core/activityContent/errors.ts
@@ -15,7 +15,7 @@ export class ActivityContentError extends DSNPError {
  * to pass validation.
  */
 export class InvalidActivityContentError extends ActivityContentError {
-  constructor() {
-    super("The activity content object provided is invalid.");
+  constructor(message?: string) {
+    super("Invalid ActivityContent: " + (message || "unknown error"));
   }
 }

--- a/src/core/activityContent/factories.ts
+++ b/src/core/activityContent/factories.ts
@@ -6,7 +6,7 @@ interface ActivityContentBase {
   type: string;
   name?: string;
   published?: string;
-  location?: Array<ActivityContentLocation> | ActivityContentLocation;
+  location?: ActivityContentLocation;
   tag?: Array<ActivityContentTag> | ActivityContentTag;
 }
 

--- a/src/core/activityContent/validation.test.ts
+++ b/src/core/activityContent/validation.test.ts
@@ -1,13 +1,398 @@
-import { ActivityContentNote, ActivityContentProfile } from "./factories";
+import { ActivityContentAttachment, ActivityContentNote, ActivityContentProfile } from "./factories";
 import {
   requireActivityContentNoteType,
-  requireIsActivityContentProfile,
+  requireIsActivityContentProfileType,
   requireValidActivityContentNote,
   requireValidActivityContentProfile,
+  requireGetSupportedContentAttachments,
 } from "./validation";
 
 describe("activity content validations", () => {
-  describe("isActivityContentNote", () => {
+  describe("requireGetSupportedContentAttachments", () => {
+    describe("when there is one valid attachment", () => {
+      const testCases: Record<string, Array<ActivityContentAttachment>> = {
+        "Image attachment with multiple urls and only one is valid": [
+          {
+            type: "Image",
+            url: [
+              {
+                type: "Link",
+                href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+                mediaType: "image/jpg",
+                hash: [
+                  {
+                    algorithm: "keccak256",
+                    value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                  },
+                ],
+              },
+              {
+                type: "Link",
+                href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+                mediaType: "image/foo",
+                hash: [
+                  {
+                    algorithm: "keccak256",
+                    value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        "Video attachment with multiple urls but only one has a valid hash algorithm": [
+          {
+            type: "Video",
+            name: "My video",
+            duration: "00:00:47",
+            url: [
+              {
+                type: "Link",
+                href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/Big_Buck_Bunny_4K.webm",
+                mediaType: "video/webm",
+                hash: [
+                  {
+                    algorithm: "keccak256",
+                    value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a",
+                  },
+                  {
+                    algorithm: "secp256k1",
+                    value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a29999",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        "with a link attachment": [
+          {
+            type: "Link",
+            href: "https://dsnp.org",
+          },
+        ],
+        "with an audio attachment": [
+          {
+            type: "Audio",
+            url: [
+              {
+                type: "Link",
+                href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
+                mediaType: "audio/ogg",
+                hash: [
+                  {
+                    algorithm: "keccak256",
+                    value: "0x3b33df3d163e86514e9041ac97e3d920a75bbafa8d9c1489e631897874b762cc",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      for (const tc in testCases) {
+        it(`returns the attachment ${tc}`, () => {
+          expect(requireGetSupportedContentAttachments(testCases[tc])).toEqual(testCases[tc]);
+        });
+      }
+    });
+    describe("when there is one invalid attachment", () => {
+      [
+        {
+          name: "an audio attachment with a bad duration value",
+          expErr: "ActivityContentAudio duration is invalid",
+          attachment: [
+            {
+              name: "I have a name",
+              duration: "53 minutes",
+              type: "Audio",
+              url: [
+                {
+                  type: "Link",
+                  href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
+                  mediaType: "audio/ogg",
+                  hash: [
+                    {
+                      algorithm: "keccak256",
+                      value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: "an image attachment with a bad name value",
+          expErr: "ActivityContentImage name is not a string",
+          attachment: [
+            {
+              type: "Image",
+              name: 1234,
+              url: [
+                {
+                  type: "Link",
+                  href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+                  mediaType: "image/jpg",
+                  hash: [
+                    {
+                      algorithm: "keccak256",
+                      value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: "a video attachment with an unsupported mediaType",
+          expErr: "ActivityContentVideo has no supported media types",
+          attachment: [
+            {
+              type: "Video",
+              url: [
+                {
+                  type: "Link",
+                  href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/Big_Buck_Bunny_4K.webm",
+                  mediaType: "video/avi",
+                  hash: [
+                    {
+                      algorithm: "keccak256",
+                      value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: "a link attachment with an invalid protocol",
+          expErr: "ActivityContentLink href is invalid",
+          attachment: [
+            {
+              type: "Link",
+              href: "ftp://dsnp.org",
+            },
+          ],
+        },
+        {
+          name: "audio attachment with an unsupported algorithm",
+          expErr: "ActivityContent hash algorithms must contain at least one of: keccak256",
+          attachment: [
+            {
+              type: "Audio",
+              url: [
+                {
+                  type: "Link",
+                  href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
+                  mediaType: "audio/ogg",
+                  hash: [
+                    {
+                      algorithm: "secp256k1",
+                      value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: "audio attachment with undefined hash",
+          expErr: "ActivityContentAudioLink hash is invalid",
+          attachment: [
+            {
+              type: "Audio",
+              url: [
+                {
+                  type: "Link",
+                  href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
+                  mediaType: "audio/ogg",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: "a link attachment with no type",
+          expErr: "ActivityContentAttachment type is invalid",
+          attachment: [
+            {
+              href: "https://dsnp.org",
+            },
+          ],
+        },
+      ].forEach((testCase) => {
+        it(`${testCase.name} throws error`, () => {
+          expect(() => requireGetSupportedContentAttachments(testCase.attachment)).toThrowError(testCase.expErr);
+        });
+      });
+    });
+    describe("when there are multiple attachments", () => {
+      it("with a single invalid attachment url, throws expected error", () => {
+        const missingMediaType = [
+          {
+            type: "Image",
+            url: [
+              {
+                type: "Link",
+                href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+                hash: [
+                  {
+                    algorithm: "keccak256",
+                    value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+        expect(() => requireGetSupportedContentAttachments(missingMediaType)).toThrowError(
+          "DSNPError: Invalid ActivityContent: ActivityContentImageLink mediaType is not a string"
+        );
+      });
+
+      it("with one attachment that has multiple urls where only one is valid, returns the attachment", () => {
+        const multipleUrls = [
+          {
+            type: "Image",
+            url: [
+              {
+                type: "Link",
+                href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+                mediaType: "image/bar",
+                hash: [
+                  {
+                    algorithm: "keccak256",
+                    value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                  },
+                ],
+              },
+              {
+                type: "Link",
+                href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+                mediaType: "image/foo",
+                hash: [
+                  {
+                    algorithm: "keccak256",
+                    value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                  },
+                ],
+              },
+              {
+                type: "Link",
+                href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+                mediaType: "image/jpg",
+                hash: [
+                  {
+                    algorithm: "keccak256",
+                    value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+        expect(requireGetSupportedContentAttachments(multipleUrls)).toHaveLength(1);
+      });
+
+      it("with multiple attachments but only one is usable/valid, returns the valid one", () => {
+        const validAttachment = {
+          type: "Image",
+          url: [
+            {
+              type: "Link",
+              href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+              mediaType: "image/jpg",
+              hash: [
+                {
+                  algorithm: "keccak256",
+                  value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                },
+              ],
+            },
+          ],
+        };
+        const invalidAttachment = {
+          type: "Image",
+          url: [
+            {
+              type: "Link",
+              href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+              hash: [
+                {
+                  algorithm: "keccak256",
+                  value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                },
+              ],
+            },
+          ],
+        };
+
+        expect(requireGetSupportedContentAttachments([validAttachment, invalidAttachment])).toHaveLength(1);
+      });
+
+      it("with multiple link attachments and one is invalid, returns the valid one", () => {
+        const validAttachment = {
+          type: "Link",
+          href: "https://dsnp.org",
+        };
+        const invalidAttachment = {
+          type: "Link",
+          href: "ftp://dsnp.org",
+        };
+        expect(requireGetSupportedContentAttachments([validAttachment, invalidAttachment])).toHaveLength(1);
+      });
+      it("with multiple attachments of different types", () => {
+        const validImageAttachment = {
+          type: "Image",
+          url: [
+            {
+              type: "Link",
+              href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+              mediaType: "image/jpg",
+              hash: [
+                {
+                  algorithm: "keccak256",
+                  value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                },
+              ],
+            },
+          ],
+        };
+        const validLinkAttachment = {
+          type: "Link",
+          href: "https://dsnp.org",
+        };
+        const validVideoAttachment = {
+          type: "Video",
+          url: [
+            {
+              type: "Link",
+              href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/Big_Buck_Bunny_4K.webm",
+              mediaType: "video/webm",
+              hash: [
+                {
+                  algorithm: "keccak256",
+                  value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a",
+                },
+                {
+                  algorithm: "secp256k1",
+                  value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a29999",
+                },
+              ],
+            },
+          ],
+        };
+
+        expect(
+          requireGetSupportedContentAttachments([validLinkAttachment, validImageAttachment, validVideoAttachment])
+        ).toHaveLength(3);
+      });
+    });
+  });
+  describe("requireActivityContentNoteType", () => {
     describe("when a Note's types are valid", () => {
       const activityContentNotes: Record<string, ActivityContentNote> = {
         "with no attachments": {
@@ -15,6 +400,23 @@ describe("activity content validations", () => {
           type: "Note",
           content: "Hello world!",
           mediaType: "text/plain",
+        },
+        "with a hashtag": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Note",
+          content: "Hello world!",
+          mediaType: "text/plain",
+          tag: [{ name: "happiness" }, { name: "feels" }, { name: "kawaii" }],
+        },
+        "with a mention": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Note",
+          content: "Hello world!",
+          mediaType: "text/plain",
+          tag: [
+            { type: "Mention", id: "0x1001", name: "Spoopy" },
+            { type: "Mention", id: "0x1002", name: "Snoopy" },
+          ],
         },
         "with an audio attachment": {
           "@context": "https://www.w3.org/ns/activitystreams",
@@ -88,6 +490,41 @@ describe("activity content validations", () => {
             },
           ],
         },
+        "with a video attachment that has one supported media type and one not": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Note",
+          content: "What an adventure!",
+          mediaType: "text/plain",
+          attachment: [
+            {
+              type: "Video",
+              url: [
+                {
+                  type: "Link",
+                  href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/Big_Buck_Bunny_4K.webm",
+                  mediaType: "video/webm",
+                  hash: [
+                    {
+                      algorithm: "keccak256",
+                      value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a",
+                    },
+                  ],
+                },
+                {
+                  type: "Link",
+                  href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/AWindowsMediaVideo.wmv",
+                  mediaType: "video/wmv",
+                  hash: [
+                    {
+                      algorithm: "keccak256",
+                      value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a99999",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
         "with a link attachment": {
           "@context": "https://www.w3.org/ns/activitystreams",
           type: "Note",
@@ -100,7 +537,7 @@ describe("activity content validations", () => {
             },
           ],
         },
-        "with a single location": {
+        "with a location": {
           "@context": "https://www.w3.org/ns/activitystreams",
           type: "Note",
           content: "Hello world!",
@@ -120,14 +557,14 @@ describe("activity content validations", () => {
 
       for (const key in activityContentNotes) {
         it(`returns true for ${key}`, () => {
-          expect(requireActivityContentNoteType(activityContentNotes[key])).toEqual(true);
+          expect(() => requireActivityContentNoteType(activityContentNotes[key])).not.toThrow();
         });
       }
     });
-    describe("when a note fails type checks because of", () => {
+    describe("when a Note fails type checks because of", () => {
       [
         {
-          testName: "a missing mediaType",
+          name: "a missing mediaType",
           testObject: {
             "@context": "https://www.w3.org/ns/activitystreams",
             type: "Note",
@@ -136,181 +573,8 @@ describe("activity content validations", () => {
           expErr: "invalid ActivityContentNote mediaType",
         },
         {
-          testName: "audio attachment with undefined hash",
-          expErr: "ActivityContentAudioLink hash is invalid",
-          testObject: {
-            "@context": "https://www.w3.org/ns/activitystreams",
-            type: "Note",
-            content: "Feel like I've heard this before!",
-            mediaType: "text/plain",
-            attachment: [
-              {
-                type: "Audio",
-                url: [
-                  {
-                    type: "Link",
-                    href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
-                    mediaType: "audio/ogg",
-                  },
-                ],
-              },
-            ],
-          },
-        },
-        {
-          testName: "audio attachment with hash value that is invalid",
-          expErr: "ActivityContentHash value field is not a string",
-          testObject: {
-            "@context": "https://www.w3.org/ns/activitystreams",
-            type: "Note",
-            content: "Feel like I've heard this before!",
-            mediaType: "text/plain",
-            attachment: [
-              {
-                type: "Audio",
-                url: [
-                  {
-                    type: "Link",
-                    href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
-                    mediaType: "audio/ogg",
-                    hash: [
-                      {
-                        algorithm: "keccak256",
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        },
-        {
-          testName: "audio attachment with an unsupported algorithm",
-          expErr: "ActivityContentHash has unsupported algorithm",
-          testObject: {
-            "@context": "https://www.w3.org/ns/activitystreams",
-            type: "Note",
-            content: "Feel like I've heard this before!",
-            mediaType: "text/plain",
-            attachment: [
-              {
-                type: "Audio",
-                url: [
-                  {
-                    type: "Link",
-                    href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
-                    mediaType: "audio/ogg",
-                    hash: [
-                      {
-                        algorithm: "secp256k1",
-                        value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        },
-        {
-          testName: "audio attachment with a malformed hash",
-          expErr: "ActivityContentHash value is invalid",
-          testObject: {
-            "@context": "https://www.w3.org/ns/activitystreams",
-            type: "Note",
-            content: "Feel like I've heard this before!",
-            mediaType: "text/plain",
-            attachment: [
-              {
-                type: "Audio",
-                url: [
-                  {
-                    type: "Link",
-                    href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
-                    mediaType: "audio/ogg",
-                    hash: [
-                      {
-                        algorithm: "keccak256",
-                        value: "bad",
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        },
-        {
-          testName: "image attachment missing a mediaType",
-          expErr: "ActivityContentImageLink mediaType is not a string",
-          testObject: {
-            "@context": "https://www.w3.org/ns/activitystreams",
-            type: "Note",
-            content: "Interesting guy!",
-            mediaType: "text/plain",
-            attachment: [
-              {
-                type: "Image",
-                url: [
-                  {
-                    type: "Link",
-                    href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
-                    hash: [
-                      {
-                        algorithm: "keccak256",
-                        value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        },
-        {
-          testName: "video attachment with a non-array URL field",
-          expErr: "invalid ActivityContentVideoLink",
-          testObject: {
-            "@context": "https://www.w3.org/ns/activitystreams",
-            type: "Note",
-            content: "What an adventure!",
-            mediaType: "text/plain",
-            attachment: [
-              {
-                type: "Video",
-                url: {
-                  type: "Link",
-                  href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/Big_Buck_Bunny_4K.webm",
-                  mediaType: "video/webm",
-                  hash: [
-                    {
-                      algorithm: "keccak256",
-                      value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a",
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-        },
-        {
-          testName: "a link attachment with no type",
-          expErr: "unknown activity content type: undefined",
-          testObject: {
-            "@context": "https://www.w3.org/ns/activitystreams",
-            type: "Note",
-            content: "Interesting project!",
-            mediaType: "text/plain",
-            attachment: [
-              {
-                href: "https://dsnp.org",
-              },
-            ],
-          },
-        },
-        {
-          testName: "an invalid location type",
-          expErr: "ActivityContentLocation is not a record",
+          name: "an invalid location type",
+          expErr: "ActivityContentNote location is not a record type",
           testObject: {
             "@context": "https://www.w3.org/ns/activitystreams",
             type: "Note",
@@ -320,7 +584,7 @@ describe("activity content validations", () => {
           },
         },
       ].forEach((testCase) => {
-        it(`${testCase.testName} throws correct error`, () => {
+        it(`${testCase.name} throws correct error`, () => {
           expect(() => requireActivityContentNoteType(testCase.testObject)).toThrowError(
             "Invalid ActivityContent: " + testCase.expErr
           );
@@ -329,7 +593,7 @@ describe("activity content validations", () => {
     });
   });
 
-  describe("isActivityContentProfile", () => {
+  describe("requireIsActivityContentProfile", () => {
     describe("when the profile is valid", () => {
       const activityContentProfiles: Record<string, ActivityContentProfile> = {
         "a profile object": {
@@ -365,12 +629,72 @@ describe("activity content validations", () => {
 
       for (const key in activityContentProfiles) {
         it(`returns true for ${key}`, () => {
-          expect(requireIsActivityContentProfile(activityContentProfiles[key])).toEqual(true);
+          expect(requireIsActivityContentProfileType(activityContentProfiles[key])).toEqual(true);
         });
       }
     });
     describe("when the profile is invalid", () => {
       [
+        {
+          name: "when the name is invalid",
+          expErr: "ActivityContentProfile name is not a string",
+          testObject: {
+            name: 1234,
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Profile",
+            content: "Feel like I've heard this before!",
+          },
+        },
+        {
+          name: "when the context is invalid",
+          expErr: "invalid ActivityContentProfile @context",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreamzzz",
+            type: "Profile",
+            content: "Me",
+          },
+        },
+        {
+          name: "icon has invalid hash value",
+          expErr: "ActivityContentHash value field is not a string",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Profile",
+            content: "Feel like I've heard this before!",
+            icon: [
+              {
+                type: "Link",
+                href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.jpg",
+                mediaType: "image/jpg",
+                hash: [
+                  {
+                    algorithm: "keccak256",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          name: "icon is missing a mediaType",
+          expErr: "ActivityContentImageLink mediaType is not a string",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Profile",
+            content: "Interesting guy!",
+            icon: [
+              {
+                type: "Link",
+                href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.jpg",
+                hash: [
+                  {
+                    algorithm: "keccak256",
+                  },
+                ],
+              },
+            ],
+          },
+        },
         {
           name: "a profile undefined type field",
           expErr: "invalid ActivityContentProfile type",
@@ -425,15 +749,15 @@ describe("activity content validations", () => {
           },
         },
       ].forEach((testCase) => {
-        it(`returns false for ${testCase.name}`, () => {
-          expect(() => requireIsActivityContentProfile(testCase.testObject)).toThrowError(
+        it(`throws error for ${testCase.name}`, () => {
+          expect(() => requireIsActivityContentProfileType(testCase.testObject)).toThrowError(
             "DSNPError: Invalid ActivityContent: " + testCase.expErr
           );
         });
       });
     });
   });
-  describe("isValidActivityContentNote", () => {
+  describe("requireValidActivityContentNote", () => {
     describe("when the Note is valid", () => {
       const validActivityContentNotes: Record<string, ActivityContentNote> = {
         "a note with no attachments": {
@@ -490,7 +814,7 @@ describe("activity content validations", () => {
             },
           ],
         },
-        "a note with an video attachment": {
+        "a note with a video attachment": {
           "@context": "https://www.w3.org/ns/activitystreams",
           type: "Note",
           content: "What an adventure!",
@@ -514,7 +838,7 @@ describe("activity content validations", () => {
             },
           ],
         },
-        "a note with an link attachment": {
+        "a note with a link attachment": {
           "@context": "https://www.w3.org/ns/activitystreams",
           type: "Note",
           content: "Interesting project!",
@@ -523,6 +847,26 @@ describe("activity content validations", () => {
             {
               type: "Link",
               href: "https://dsnp.org",
+            },
+          ],
+        },
+        "a note with multiple attachments": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Note",
+          content: "Interesting project!",
+          mediaType: "text/plain",
+          attachment: [
+            {
+              type: "Link",
+              href: "https://dsnp.org",
+            },
+            {
+              type: "Link",
+              href: "https://placekitten.com",
+            },
+            {
+              type: "Link",
+              href: "https://examplecompany.com",
             },
           ],
         },
@@ -536,8 +880,8 @@ describe("activity content validations", () => {
       };
 
       for (const key in validActivityContentNotes) {
-        it(`Returns true for ${key}`, () => {
-          expect(() => requireValidActivityContentNote(validActivityContentNotes[key])).toBeTruthy();
+        it(`Does not throw for a ${key}`, () => {
+          expect(() => requireValidActivityContentNote(validActivityContentNotes[key])).not.toThrow();
         });
       }
     });
@@ -562,109 +906,8 @@ describe("activity content validations", () => {
           },
         },
         {
-          name: "a note with an audio attachment with an invalid hash",
-          expErr: "ActivityContentHash value is invalid",
-
-          note: {
-            "@context": "https://www.w3.org/ns/activitystreams",
-            type: "Note",
-            content: "Feel like I've heard this before!",
-            mediaType: "text/plain",
-            attachment: [
-              {
-                type: "Audio",
-                url: [
-                  {
-                    type: "Link",
-                    href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
-                    mediaType: "audio/ogg",
-                    hash: [
-                      {
-                        algorithm: "keccak256",
-                        value: "0x3b33df3d",
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        },
-        {
-          name: "a note with an image attachment with an unsupported hash algorithm",
-          expErr: "ActivityContentHash has unsupported algorithm",
-          note: {
-            "@context": "https://www.w3.org/ns/activitystreams",
-            type: "Note",
-            content: "Interesting guy!",
-            mediaType: "text/plain",
-            attachment: [
-              {
-                type: "Image",
-                url: [
-                  {
-                    type: "Link",
-                    href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
-                    mediaType: "image/jpg",
-                    hash: [
-                      {
-                        algorithm: "MD5",
-                        value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        },
-        {
-          name: "a note with an video attachment with an unsupported mediaType",
-          expErr: "ActivityContentVideo url mediaType is unsupported",
-          note: {
-            "@context": "https://www.w3.org/ns/activitystreams",
-            type: "Note",
-            content: "What an adventure!",
-            mediaType: "text/plain",
-            attachment: [
-              {
-                type: "Video",
-                url: [
-                  {
-                    type: "Link",
-                    href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/Big_Buck_Bunny_4K.webm",
-                    mediaType: "video/avi",
-                    hash: [
-                      {
-                        algorithm: "keccak256",
-                        value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a",
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        },
-        {
-          name: "a note with a link attachment with an invalid protocol",
-          expErr: "ActivityContentLink href protocol must be one of: http:, https:",
-          note: {
-            "@context": "https://www.w3.org/ns/activitystreams",
-            type: "Note",
-            content: "Interesting project!",
-            mediaType: "text/plain",
-            attachment: [
-              {
-                type: "Link",
-                href: "ftp://dsnp.org",
-              },
-            ],
-          },
-        },
-        {
           name: "with a location that is not a record",
-          expErr: "ActivityContentLocation is not a record",
+          expErr: "ActivityContentNote location is not a record type",
           note: {
             location: "bad",
             "@context": "https://www.w3.org/ns/activitystreams",
@@ -696,7 +939,7 @@ describe("activity content validations", () => {
       });
     });
   });
-  describe("isValidActivityContentProfile", () => {
+  describe("requireValidActivityContentProfile", () => {
     describe("when profile is valid", () => {
       const validActivityContentProfiles: Record<string, ActivityContentProfile> = {
         "a profile object": {
@@ -709,6 +952,21 @@ describe("activity content validations", () => {
           type: "Profile",
           name: "jaboukie",
           published: "2000-01-01T00:00:00+00:00",
+        },
+        "a profile object with a location": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Profile",
+          name: "jaboukie",
+          location: {
+            type: "Place",
+            name: "My house",
+            accuracy: 1,
+            altitude: 1,
+            latitude: 1,
+            longitude: 1,
+            radius: 1,
+            units: "string",
+          },
         },
         "a profile object with icon": {
           "@context": "https://www.w3.org/ns/activitystreams",
@@ -739,7 +997,40 @@ describe("activity content validations", () => {
     describe("when profile is invalid", () => {
       [
         {
-          name: "a profile object with an invalid published timestamp",
+          name: "when location has the wrong type",
+          expErr: "ActivityContentLocation type is not 'Place'",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Profile",
+            content: "Me",
+            location: {
+              type: "bad",
+              name: "This is fine",
+            },
+          },
+        },
+        {
+          name: "when a single tag is invalid",
+          expErr: "ActivityContentHashtag name is not a string",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Profile",
+            content: "Me",
+            tag: { hashtag: "spoopy" },
+          },
+        },
+        {
+          name: "when a mention tag is invalid",
+          expErr: "ActivityContentMention id is not a valid DSNPUserId",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Profile",
+            content: "Me",
+            tag: [{ type: "Mention", id: 1234, name: "spoopy" }],
+          },
+        },
+        {
+          name: "with an invalid published timestamp",
           expErr: "ActivityContentProfile published is invalid",
           testObject: {
             "@context": "https://www.w3.org/ns/activitystreams",
@@ -749,7 +1040,7 @@ describe("activity content validations", () => {
           },
         },
         {
-          name: "a profile object with an icon with an invalid hash",
+          name: "with an icon with an invalid hash",
           expErr: "ActivityContentHash value is invalid",
           testObject: {
             "@context": "https://www.w3.org/ns/activitystreams",
@@ -771,8 +1062,8 @@ describe("activity content validations", () => {
           },
         },
         {
-          name: "a profile object with an icon with an unsupported hash algorithm",
-          expErr: "ActivityContentHash has unsupported algorithm",
+          name: "with an icon with an unsupported hash algorithm",
+          expErr: "ActivityContent hash algorithms must contain at least one of: keccak256",
           testObject: {
             "@context": "https://www.w3.org/ns/activitystreams",
             type: "Profile",
@@ -792,8 +1083,50 @@ describe("activity content validations", () => {
             ],
           },
         },
+        {
+          name: "with an icon with an unsupported protocol link",
+          expErr: "ActivityContentLink href is invalid",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Profile",
+            name: "dril",
+            icon: [
+              {
+                type: "Link",
+                mediaType: "image/jpg",
+                href: "ftp://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
+                hash: [
+                  {
+                    algorithm: "keccak256",
+                    value: "0x00a63eb58f6ce7fccd93e2d004fed81da5ec1a9747b63f5f1bf80742026efea7",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          name: "with a location missing a type",
+          expErr: "ActivityContentLocation type is not 'Place'",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Profile",
+            name: "jaboukie",
+            location: { name: "My house", units: "m" },
+          },
+        },
+        {
+          name: "with a location with bad numbers",
+          expErr: "ActivityContentLocation latitude is not a number",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Profile",
+            name: "jaboukie",
+            location: { type: "Place", name: "My house", latitude: "string" },
+          },
+        },
       ].forEach((testCase) => {
-        it(`returns false for ${testCase.name}`, () => {
+        it(`throws error for ${testCase.name}`, () => {
           expect(() => requireValidActivityContentProfile(testCase.testObject)).toThrowError(
             "DSNPError: Invalid ActivityContent: " + testCase.expErr
           );

--- a/src/core/activityContent/validation.test.ts
+++ b/src/core/activityContent/validation.test.ts
@@ -1,222 +1,330 @@
 import { ActivityContentNote, ActivityContentProfile } from "./factories";
 import {
-  isActivityContentNote,
+  requireActivityContentNoteType,
   isActivityContentProfile,
-  isValidActivityContentNote,
+  requireValidActivityContentNote,
   isValidActivityContentProfile,
 } from "./validation";
 
 describe("activity content validations", () => {
   describe("isActivityContentNote", () => {
-    const activityContentNotes: Record<string, ActivityContentNote> = {
-      "a note with no attachements": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Hello world!",
-        mediaType: "text/plain",
-      },
-      "a note with an audio attachement": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Feel like I've heard this before!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            type: "Audio",
-            url: [
-              {
-                type: "Link",
-                href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
-                mediaType: "audio/ogg",
-                hash: [
-                  {
-                    algorithm: "keccak256",
-                    value: "0x3b33df3d163e86514e9041ac97e3d920a75bbafa8d9c1489e631897874b762cc",
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      "a note with an image attachement": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Interesting guy!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            type: "Image",
-            url: [
-              {
-                type: "Link",
-                href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
-                mediaType: "image/jpg",
-                hash: [
-                  {
-                    algorithm: "keccak256",
-                    value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      "a note with an video attachement": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "What an adventure!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            type: "Video",
-            url: [
-              {
-                type: "Link",
-                href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/Big_Buck_Bunny_4K.webm",
-                mediaType: "video/webm",
-                hash: [
-                  {
-                    algorithm: "keccak256",
-                    value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a",
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      "a note with an link attachement": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Interesting project!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            type: "Link",
-            href: "https://dsnp.org",
-          },
-        ],
-      },
-    };
-
-    for (const key in activityContentNotes) {
-      it(`returns true for ${key}`, () => {
-        expect(isActivityContentNote(activityContentNotes[key])).toEqual(true);
-      });
-    }
-
-    const notActivityContentNotes: Record<string, unknown> = {
-      "a note missing a mediaType": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Hello world!",
-      },
-      "a note with an audio attachement missing a hash": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Feel like I've heard this before!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            type: "Audio",
-            url: [
-              {
-                type: "Link",
-                href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
-                mediaType: "audio/ogg",
-              },
-            ],
-          },
-        ],
-      },
-      "a note with an audio attachement missing a hash value": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Feel like I've heard this before!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            type: "Audio",
-            url: [
-              {
-                type: "Link",
-                href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
-                mediaType: "audio/ogg",
-                hash: [
-                  {
-                    algorithm: "keccak256",
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      "a note with an image attachement missing a mediaType": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Interesting guy!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            type: "Image",
-            url: [
-              {
-                type: "Link",
-                href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
-                hash: [
-                  {
-                    algorithm: "keccak256",
-                    value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      "a note with an video attachement with a non-array URL field": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "What an adventure!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            type: "Video",
-            url: {
-              type: "Link",
-              href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/Big_Buck_Bunny_4K.webm",
-              mediaType: "video/webm",
-              hash: [
+    describe("when a Note's types are valid", () => {
+      const activityContentNotes: Record<string, ActivityContentNote> = {
+        "with no attachments": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Note",
+          content: "Hello world!",
+          mediaType: "text/plain",
+        },
+        "with an audio attachment": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Note",
+          content: "Feel like I've heard this before!",
+          mediaType: "text/plain",
+          attachment: [
+            {
+              type: "Audio",
+              url: [
                 {
-                  algorithm: "keccak256",
-                  value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a",
+                  type: "Link",
+                  href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
+                  mediaType: "audio/ogg",
+                  hash: [
+                    {
+                      algorithm: "keccak256",
+                      value: "0x3b33df3d163e86514e9041ac97e3d920a75bbafa8d9c1489e631897874b762cc",
+                    },
+                  ],
                 },
               ],
             },
+          ],
+        },
+        "with an image attachment": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Note",
+          content: "Interesting guy!",
+          mediaType: "text/plain",
+          attachment: [
+            {
+              type: "Image",
+              url: [
+                {
+                  type: "Link",
+                  href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+                  mediaType: "image/jpg",
+                  hash: [
+                    {
+                      algorithm: "keccak256",
+                      value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        "with a video attachment": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Note",
+          content: "What an adventure!",
+          mediaType: "text/plain",
+          attachment: [
+            {
+              type: "Video",
+              url: [
+                {
+                  type: "Link",
+                  href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/Big_Buck_Bunny_4K.webm",
+                  mediaType: "video/webm",
+                  hash: [
+                    {
+                      algorithm: "keccak256",
+                      value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        "with a link attachment": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Note",
+          content: "Interesting project!",
+          mediaType: "text/plain",
+          attachment: [
+            {
+              type: "Link",
+              href: "https://dsnp.org",
+            },
+          ],
+        },
+        "with a single location": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Note",
+          content: "Hello world!",
+          mediaType: "text/plain",
+          location: {
+            type: "Place",
+            name: "Topkapi Palace, Istanbul, Turkey",
+            accuracy: 10,
+            altitude: 51,
+            latitude: 41.0115195,
+            longitude: 28.9811849,
+            radius: 100,
+            units: "m",
           },
-        ],
-      },
-      "a note with an link attachement with a no type": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Interesting project!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            href: "https://dsnp.org",
-          },
-        ],
-      },
-    };
+        },
+      };
 
-    for (const key in notActivityContentNotes) {
-      it(`returns false for ${key}`, () => {
-        expect(isActivityContentNote(notActivityContentNotes[key])).toEqual(false);
+      for (const key in activityContentNotes) {
+        it(`returns true for ${key}`, () => {
+          expect(requireActivityContentNoteType(activityContentNotes[key])).toEqual(true);
+        });
+      }
+    });
+    describe("when a note fails type checks because of", () => {
+      [
+        {
+          testName: "a missing mediaType",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "Hello world!",
+          },
+          expErr: "invalid mediaType",
+        },
+        {
+          testName: "a audio attachment with undefined hash",
+          expErr: "ActivityContentAudioLink hash is invalid",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "Feel like I've heard this before!",
+            mediaType: "text/plain",
+            attachment: [
+              {
+                type: "Audio",
+                url: [
+                  {
+                    type: "Link",
+                    href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
+                    mediaType: "audio/ogg",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          testName: "a audio attachment with hash value that is invalid",
+          expErr: "ActivityContentHash value field is not a string",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "Feel like I've heard this before!",
+            mediaType: "text/plain",
+            attachment: [
+              {
+                type: "Audio",
+                url: [
+                  {
+                    type: "Link",
+                    href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
+                    mediaType: "audio/ogg",
+                    hash: [
+                      {
+                        algorithm: "keccak256",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          testName: "a audio attachment with an unsupported algorithm",
+          expErr: "ActivityContentHash has unsupported algorithm",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "Feel like I've heard this before!",
+            mediaType: "text/plain",
+            attachment: [
+              {
+                type: "Audio",
+                url: [
+                  {
+                    type: "Link",
+                    href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
+                    mediaType: "audio/ogg",
+                    hash: [
+                      {
+                        algorithm: "secp256k1",
+                        value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          testName: "a audio attachment with a malformed hash",
+          expErr: "ActivityContentHash value is invalid",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "Feel like I've heard this before!",
+            mediaType: "text/plain",
+            attachment: [
+              {
+                type: "Audio",
+                url: [
+                  {
+                    type: "Link",
+                    href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
+                    mediaType: "audio/ogg",
+                    hash: [
+                      {
+                        algorithm: "keccak256",
+                        value: "bad",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          testName: "a image attachment missing a mediaType",
+          expErr: "ActivityContentImageLink mediaType is not a string",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "Interesting guy!",
+            mediaType: "text/plain",
+            attachment: [
+              {
+                type: "Image",
+                url: [
+                  {
+                    type: "Link",
+                    href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+                    hash: [
+                      {
+                        algorithm: "keccak256",
+                        value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          testName: "a video attachment with a non-array URL field",
+          expErr: "invalid ActivityContentVideoLink",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "What an adventure!",
+            mediaType: "text/plain",
+            attachment: [
+              {
+                type: "Video",
+                url: {
+                  type: "Link",
+                  href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/Big_Buck_Bunny_4K.webm",
+                  mediaType: "video/webm",
+                  hash: [
+                    {
+                      algorithm: "keccak256",
+                      value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          testName: "a link attachment with no type",
+          expErr: "unknown activity content type: undefined",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "Interesting project!",
+            mediaType: "text/plain",
+            attachment: [
+              {
+                href: "https://dsnp.org",
+              },
+            ],
+          },
+        },
+        {
+          testName: "an invalid location type",
+          expErr: "ActivityContentLocation is not a record",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "Hello world!",
+            mediaType: "text/plain",
+            location: "My house",
+          },
+        },
+      ].forEach((testCase) => {
+        it(`${testCase.testName} throws correct error`, () => {
+          expect(() => requireActivityContentNoteType(testCase.testObject)).toThrowError(testCase.expErr);
+        });
       });
-    }
+    });
   });
 
   describe("isActivityContentProfile", () => {
@@ -284,204 +392,244 @@ describe("activity content validations", () => {
   });
 
   describe("isValidActivityContentNote", () => {
-    const validActivityContentNotes: Record<string, ActivityContentNote> = {
-      "a note with no attachements": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Hello world!",
-        mediaType: "text/plain",
-      },
-      "a note with an audio attachement": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Feel like I've heard this before!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            type: "Audio",
-            url: [
-              {
-                type: "Link",
-                href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
-                mediaType: "audio/ogg",
-                hash: [
-                  {
-                    algorithm: "keccak256",
-                    value: "0x3b33df3d163e86514e9041ac97e3d920a75bbafa8d9c1489e631897874b762cc",
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      "a note with an image attachement": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Interesting guy!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            type: "Image",
-            url: [
-              {
-                type: "Link",
-                href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
-                mediaType: "image/jpg",
-                hash: [
-                  {
-                    algorithm: "keccak256",
-                    value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      "a note with an video attachement": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "What an adventure!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            type: "Video",
-            url: [
-              {
-                type: "Link",
-                href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/Big_Buck_Bunny_4K.webm",
-                mediaType: "video/webm",
-                hash: [
-                  {
-                    algorithm: "keccak256",
-                    value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a",
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      "a note with an link attachement": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Interesting project!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            type: "Link",
-            href: "https://dsnp.org",
-          },
-        ],
-      },
-    };
+    describe("when the Note is valid", () => {
+      const validActivityContentNotes: Record<string, ActivityContentNote> = {
+        "a note with no attachments": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Note",
+          content: "Hello world!",
+          mediaType: "text/plain",
+        },
+        "a note with an audio attachment": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Note",
+          content: "Feel like I've heard this before!",
+          mediaType: "text/plain",
+          attachment: [
+            {
+              type: "Audio",
+              url: [
+                {
+                  type: "Link",
+                  href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
+                  mediaType: "audio/ogg",
+                  hash: [
+                    {
+                      algorithm: "keccak256",
+                      value: "0x3b33df3d163e86514e9041ac97e3d920a75bbafa8d9c1489e631897874b762cc",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        "a note with an image attachment": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Note",
+          content: "Interesting guy!",
+          mediaType: "text/plain",
+          attachment: [
+            {
+              type: "Image",
+              url: [
+                {
+                  type: "Link",
+                  href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+                  mediaType: "image/jpg",
+                  hash: [
+                    {
+                      algorithm: "keccak256",
+                      value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        "a note with an video attachment": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Note",
+          content: "What an adventure!",
+          mediaType: "text/plain",
+          attachment: [
+            {
+              type: "Video",
+              url: [
+                {
+                  type: "Link",
+                  href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/Big_Buck_Bunny_4K.webm",
+                  mediaType: "video/webm",
+                  hash: [
+                    {
+                      algorithm: "keccak256",
+                      value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        "a note with an link attachment": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Note",
+          content: "Interesting project!",
+          mediaType: "text/plain",
+          attachment: [
+            {
+              type: "Link",
+              href: "https://dsnp.org",
+            },
+          ],
+        },
+        "a note with a location": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Note",
+          content: "Interesting project!",
+          mediaType: "text/plain",
+          location: { type: "Place", name: "Valjevo, Serbia" },
+        },
+      };
 
-    for (const key in validActivityContentNotes) {
-      it(`returns true for ${key}`, () => {
-        expect(isValidActivityContentNote(validActivityContentNotes[key])).toEqual(true);
+      for (const key in validActivityContentNotes) {
+        it(`Does not throw an error for ${key}`, () => {
+          expect(() => requireValidActivityContentNote(validActivityContentNotes[key])).not.toThrowError();
+        });
+      }
+    });
+
+    describe("when the Note is invalid", () => {
+      [
+        {
+          name: "a note with a bad published field",
+          expErr: "published is invalid",
+          note: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "Hello world!",
+            mediaType: "text/plain",
+            published: "Yesterday",
+          },
+        },
+        {
+          name: "a note with an audio attachment with an invalid hash",
+          expErr: "published is invalid",
+
+          note: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "Feel like I've heard this before!",
+            mediaType: "text/plain",
+            attachment: [
+              {
+                type: "Audio",
+                url: [
+                  {
+                    type: "Link",
+                    href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
+                    mediaType: "audio/ogg",
+                    hash: [
+                      {
+                        algorithm: "keccak256",
+                        value: "0x3b33df3d",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          name: "a note with an image attachment without a keccak256 hash",
+          expErr: "published is invalid",
+          note: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "Interesting guy!",
+            mediaType: "text/plain",
+            attachment: [
+              {
+                type: "Image",
+                url: [
+                  {
+                    type: "Link",
+                    href: "ftp://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+                    mediaType: "image/jpg",
+                    hash: [
+                      {
+                        algorithm: "MD5",
+                        value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          name: "a note with an video attachment without a supported mediaType",
+          expErr: "published is invalid",
+          note: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "What an adventure!",
+            mediaType: "text/plain",
+            attachment: [
+              {
+                type: "Video",
+                url: [
+                  {
+                    type: "Link",
+                    href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/Big_Buck_Bunny_4K.webm",
+                    mediaType: "video/avi",
+                    hash: [
+                      {
+                        algorithm: "keccak256",
+                        value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          name: "a note with a link attachment with an invalid protocol",
+          expErr: "published is invalid",
+          note: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "Interesting project!",
+            mediaType: "text/plain",
+            attachment: [
+              {
+                type: "Link",
+                href: "ftp://dsnp.org",
+              },
+            ],
+          },
+        },
+        {
+          name: "with a location that is not an array",
+          note: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "Interesting project!",
+            mediaType: "text/plain",
+            location: "bad",
+          },
+        },
+      ].forEach((testCase) => {
+        it(`throws an error for ${testCase.name}`, () => {
+          expect(() => requireValidActivityContentNote(testCase.note)).toThrowError();
+        });
       });
-    }
-
-    const invalidActivityContentNotes: Record<string, unknown> = {
-      "a note with a bad published field": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Hello world!",
-        mediaType: "text/plain",
-        published: "Yesterday",
-      },
-      "a note with an audio attachement with an invalid hash": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Feel like I've heard this before!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            type: "Audio",
-            url: [
-              {
-                type: "Link",
-                href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
-                mediaType: "audio/ogg",
-                hash: [
-                  {
-                    algorithm: "keccak256",
-                    value: "0x3b33df3d",
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      "a note with an image attachement without a keccak256 hash": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Interesting guy!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            type: "Image",
-            url: [
-              {
-                type: "Link",
-                href: "ftp://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
-                mediaType: "image/jpg",
-                hash: [
-                  {
-                    algorithm: "MD5",
-                    value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      "a note with an video attachement without a supported mediaType": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "What an adventure!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            type: "Video",
-            url: [
-              {
-                type: "Link",
-                href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/Big_Buck_Bunny_4K.webm",
-                mediaType: "video/avi",
-                hash: [
-                  {
-                    algorithm: "keccak256",
-                    value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a",
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      "a note with an link attachement with an invalid protocol": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Note",
-        content: "Interesting project!",
-        mediaType: "text/plain",
-        attachment: [
-          {
-            type: "Link",
-            href: "ftp://dsnp.org",
-          },
-        ],
-      },
-    };
-
-    for (const key in invalidActivityContentNotes) {
-      it(`returns false for ${key}`, () => {
-        expect(isValidActivityContentNote(invalidActivityContentNotes[key])).toEqual(false);
-      });
-    }
+    });
   });
 
   describe("isValidActivityContentProfile", () => {

--- a/src/core/activityContent/validation.test.ts
+++ b/src/core/activityContent/validation.test.ts
@@ -1,5 +1,7 @@
 import { ActivityContentAttachment, ActivityContentNote, ActivityContentProfile } from "./factories";
 import {
+  isActivityContentProfileType,
+  isActivityContentNoteType,
   requireIsActivityContentNoteType,
   requireIsActivityContentProfileType,
   requireValidActivityContentNote,
@@ -8,6 +10,75 @@ import {
 } from "./validation";
 
 describe("activity content validations", () => {
+  describe("isActivityContentProfileType", () => {
+    it("returns true for a valid Profile", () => {
+      const validProfile = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        type: "Profile",
+        name: "jaboukie",
+        attachment: [
+          {
+            type: "Image",
+            url: [
+              {
+                type: "Link",
+                href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+                mediaType: "image/jpg",
+                hash: [
+                  {
+                    algorithm: "keccak256",
+                    value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(isActivityContentProfileType(validProfile)).toEqual(true);
+    });
+    it("returns false for an invalid Profile", () => {
+      const invalidProfile = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        type: "Profile",
+        name: "jaboukie",
+        attachment: [
+          {
+            type: "Image",
+            url: [
+              {
+                type: "Link",
+                href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+                mediaType: "image/jpg",
+                hash: "this should be an array",
+              },
+            ],
+          },
+        ],
+      };
+      expect(isActivityContentNoteType(invalidProfile)).toEqual(false);
+    });
+  });
+  describe("isActivityContentNoteType", () => {
+    it("returns true for a valid Note", () => {
+      const validNote = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        type: "Note",
+        content: "Hello world!",
+        mediaType: "text/plain",
+      };
+      expect(isActivityContentNoteType(validNote)).toEqual(true);
+    });
+    it("returns false for an invalid Note", () => {
+      const invalidNote = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        type: "Note",
+        content: "I am invalid because I am missing a mediaType",
+      };
+      expect(isActivityContentNoteType(invalidNote)).toEqual(false);
+    });
+  });
   describe("requireGetSupportedContentAttachments", () => {
     describe("when there is one valid attachment", () => {
       const testCases: Record<string, Array<ActivityContentAttachment>> = {
@@ -40,7 +111,7 @@ describe("activity content validations", () => {
             ],
           },
         ],
-        "Video attachment with multiple hashs but only one is a valid hash algorithm": [
+        "Video attachment with multiple hashes but only one is a valid hash algorithm": [
           {
             type: "Video",
             name: "My video",

--- a/src/core/activityContent/validation.test.ts
+++ b/src/core/activityContent/validation.test.ts
@@ -10,6 +10,14 @@ import {
 } from "./validation";
 
 describe("activity content validations", () => {
+  const consoleError = console.error;
+  beforeEach(() => {
+    console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    console.error = consoleError;
+  });
   describe("isActivityContentProfileType", () => {
     it("returns true for a valid Profile", () => {
       const validProfile = {

--- a/src/core/activityContent/validation.test.ts
+++ b/src/core/activityContent/validation.test.ts
@@ -44,7 +44,7 @@ describe("activity content validations", () => {
           {
             type: "Video",
             name: "My video",
-            duration: "00:00:47",
+            duration: "PT1H26M39S",
             url: [
               {
                 type: "Link",

--- a/src/core/activityContent/validation.test.ts
+++ b/src/core/activityContent/validation.test.ts
@@ -1,7 +1,7 @@
 import { ActivityContentAttachment, ActivityContentNote, ActivityContentProfile } from "./factories";
 import {
-  requireActivityContentNoteType,
-  requireActivityContentProfileType,
+  requireIsActivityContentNoteType,
+  requireIsActivityContentProfileType,
   requireValidActivityContentNote,
   requireValidActivityContentProfile,
   requireGetSupportedContentAttachments,
@@ -40,7 +40,7 @@ describe("activity content validations", () => {
             ],
           },
         ],
-        "Video attachment with multiple urls but only one has a valid hash algorithm": [
+        "Video attachment with multiple hashs but only one is a valid hash algorithm": [
           {
             type: "Video",
             name: "My video",
@@ -230,7 +230,7 @@ describe("activity content validations", () => {
       });
     });
     describe("when there are multiple attachments", () => {
-      it("with a single invalid attachment url, throws expected error", () => {
+      it("with a single invalid Image attachment url, throws expected error", () => {
         const missingMediaType = [
           {
             type: "Image",
@@ -253,7 +253,7 @@ describe("activity content validations", () => {
         );
       });
 
-      it("with one attachment that has multiple urls where only one is valid, returns the attachment", () => {
+      it("with one Image attachment that has multiple urls where only one is valid, returns the attachment", () => {
         const multipleUrlsAttachment = [
           {
             type: "Image",
@@ -297,7 +297,7 @@ describe("activity content validations", () => {
         expect(requireGetSupportedContentAttachments(multipleUrlsAttachment)).toStrictEqual(multipleUrlsAttachment);
       });
 
-      it("with multiple attachments but only one is usable/valid, returns the valid one", () => {
+      it("with multiple Image attachments but only one is usable/valid, returns the valid one", () => {
         const validAttachment = {
           type: "Image",
           url: [
@@ -330,7 +330,9 @@ describe("activity content validations", () => {
           ],
         };
 
-        expect(requireGetSupportedContentAttachments([validAttachment, invalidAttachment])).toHaveLength(1);
+        expect(requireGetSupportedContentAttachments([validAttachment, invalidAttachment])).toStrictEqual([
+          validAttachment,
+        ]);
       });
 
       it("with multiple link attachments and one is invalid, returns the valid one", () => {
@@ -557,7 +559,7 @@ describe("activity content validations", () => {
 
       for (const key in activityContentNotes) {
         it(`returns true for ${key}`, () => {
-          expect(() => requireActivityContentNoteType(activityContentNotes[key])).not.toThrow();
+          expect(() => requireIsActivityContentNoteType(activityContentNotes[key])).not.toThrow();
         });
       }
     });
@@ -583,9 +585,18 @@ describe("activity content validations", () => {
             location: "My house",
           },
         },
+        {
+          name: "a valid profile object",
+          expErr: "invalid ActivityContentNote type",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Profile",
+            name: "🌹🚗",
+          },
+        },
       ].forEach((testCase) => {
         it(`${testCase.name} throws correct error`, () => {
-          expect(() => requireActivityContentNoteType(testCase.testObject)).toThrowError(
+          expect(() => requireIsActivityContentNoteType(testCase.testObject)).toThrowError(
             "Invalid ActivityContent: " + testCase.expErr
           );
         });
@@ -629,7 +640,7 @@ describe("activity content validations", () => {
 
       for (const key in activityContentProfiles) {
         it(`returns true for ${key}`, () => {
-          expect(requireActivityContentProfileType(activityContentProfiles[key])).toEqual(true);
+          expect(requireIsActivityContentProfileType(activityContentProfiles[key])).toEqual(true);
         });
       }
     });
@@ -748,9 +759,19 @@ describe("activity content validations", () => {
             icon: "http://placekitten.com/700/400",
           },
         },
+        {
+          name: "a valid note type",
+          expErr: "invalid ActivityContentProfile type",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "Hello world!",
+            mediaType: "text/plain",
+          },
+        },
       ].forEach((testCase) => {
         it(`throws error for ${testCase.name}`, () => {
-          expect(() => requireActivityContentProfileType(testCase.testObject)).toThrowError(
+          expect(() => requireIsActivityContentProfileType(testCase.testObject)).toThrowError(
             "DSNPError: Invalid ActivityContent: " + testCase.expErr
           );
         });

--- a/src/core/activityContent/validation.test.ts
+++ b/src/core/activityContent/validation.test.ts
@@ -128,7 +128,7 @@ describe("activity content validations", () => {
     describe("when there is one invalid attachment", () => {
       [
         {
-          name: "an Video attachment with multiple URLs and one fails a type check (with a malformed hash)",
+          name: "a Video attachment with multiple URLs and one fails a type check (with a malformed hash)",
           expErr: "DSNPError: Invalid ActivityContent: ActivityContentHash value is invalid",
           attachment: [
             {
@@ -325,7 +325,44 @@ describe("activity content validations", () => {
         });
       });
     });
-    describe("when there are multiple attachments", () => {
+    describe("when there are multiple attachments, and one is invalid by failing type check", () => {
+      it("foo", () => {
+        const validAttachment = {
+          type: "Video",
+          url: [
+            {
+              type: "Link",
+              href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/Big_Buck_Bunny_4K.webm",
+              mediaType: "video/webm",
+              hash: [
+                {
+                  algorithm: "keccak256",
+                  value: "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a",
+                },
+              ],
+            },
+          ],
+        };
+        const typeCheckFailingAttachment = {
+          type: "Video",
+          url: [
+            {
+              type: "Link",
+              href: "https://upload.wikimedia.org/wikipedia/commons/c/c0/Happy_Rabbits_On_Farm_4K.webm",
+              mediaType: "video/webm",
+              hash: [
+                {
+                  algorithm: "keccak256",
+                  value: "0xdeadbeef",
+                },
+              ],
+            },
+          ],
+        };
+        expect(requireGetSupportedContentAttachments([validAttachment, typeCheckFailingAttachment])).toStrictEqual([
+          validAttachment,
+        ]);
+      });
       it("with two Image attachments but only one is valid, returns the valid one", () => {
         const validAttachment = {
           type: "Image",

--- a/src/core/activityContent/validation.test.ts
+++ b/src/core/activityContent/validation.test.ts
@@ -1,9 +1,9 @@
 import { ActivityContentNote, ActivityContentProfile } from "./factories";
 import {
   requireActivityContentNoteType,
-  isActivityContentProfile,
+  requireIsActivityContentProfile,
   requireValidActivityContentNote,
-  isValidActivityContentProfile,
+  requireValidActivityContentProfile,
 } from "./validation";
 
 describe("activity content validations", () => {
@@ -133,10 +133,10 @@ describe("activity content validations", () => {
             type: "Note",
             content: "Hello world!",
           },
-          expErr: "invalid mediaType",
+          expErr: "invalid ActivityContentNote mediaType",
         },
         {
-          testName: "a audio attachment with undefined hash",
+          testName: "audio attachment with undefined hash",
           expErr: "ActivityContentAudioLink hash is invalid",
           testObject: {
             "@context": "https://www.w3.org/ns/activitystreams",
@@ -158,7 +158,7 @@ describe("activity content validations", () => {
           },
         },
         {
-          testName: "a audio attachment with hash value that is invalid",
+          testName: "audio attachment with hash value that is invalid",
           expErr: "ActivityContentHash value field is not a string",
           testObject: {
             "@context": "https://www.w3.org/ns/activitystreams",
@@ -185,7 +185,7 @@ describe("activity content validations", () => {
           },
         },
         {
-          testName: "a audio attachment with an unsupported algorithm",
+          testName: "audio attachment with an unsupported algorithm",
           expErr: "ActivityContentHash has unsupported algorithm",
           testObject: {
             "@context": "https://www.w3.org/ns/activitystreams",
@@ -213,7 +213,7 @@ describe("activity content validations", () => {
           },
         },
         {
-          testName: "a audio attachment with a malformed hash",
+          testName: "audio attachment with a malformed hash",
           expErr: "ActivityContentHash value is invalid",
           testObject: {
             "@context": "https://www.w3.org/ns/activitystreams",
@@ -241,7 +241,7 @@ describe("activity content validations", () => {
           },
         },
         {
-          testName: "a image attachment missing a mediaType",
+          testName: "image attachment missing a mediaType",
           expErr: "ActivityContentImageLink mediaType is not a string",
           testObject: {
             "@context": "https://www.w3.org/ns/activitystreams",
@@ -268,7 +268,7 @@ describe("activity content validations", () => {
           },
         },
         {
-          testName: "a video attachment with a non-array URL field",
+          testName: "video attachment with a non-array URL field",
           expErr: "invalid ActivityContentVideoLink",
           testObject: {
             "@context": "https://www.w3.org/ns/activitystreams",
@@ -321,76 +321,118 @@ describe("activity content validations", () => {
         },
       ].forEach((testCase) => {
         it(`${testCase.testName} throws correct error`, () => {
-          expect(() => requireActivityContentNoteType(testCase.testObject)).toThrowError(testCase.expErr);
+          expect(() => requireActivityContentNoteType(testCase.testObject)).toThrowError(
+            "Invalid ActivityContent: " + testCase.expErr
+          );
         });
       });
     });
   });
 
   describe("isActivityContentProfile", () => {
-    const activityContentProfiles: Record<string, ActivityContentProfile> = {
-      "a profile object": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Profile",
-        name: "🌹🚗",
-      },
-      "a profile object with a published timestamp": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Profile",
-        name: "jaboukie",
-        published: "2000-01-01T00:00:00.000+00:00",
-      },
-      "a profile object with icon": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Profile",
-        name: "dril",
-        icon: [
-          {
-            type: "Link",
-            href: "https://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
-            mediaType: "image/jpg",
-            hash: [
+    describe("when the profile is valid", () => {
+      const activityContentProfiles: Record<string, ActivityContentProfile> = {
+        "a profile object": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Profile",
+          name: "🌹🚗",
+        },
+        "a profile object with a published timestamp": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Profile",
+          name: "jaboukie",
+          published: "2000-01-01T00:00:00.000+00:00",
+        },
+        "a profile object with icon": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Profile",
+          name: "dril",
+          icon: [
+            {
+              type: "Link",
+              href: "https://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
+              mediaType: "image/jpg",
+              hash: [
+                {
+                  algorithm: "keccak256",
+                  value: "0x00a63eb58f6ce7fccd93e2d004fed81da5ec1a9747b63f5f1bf80742026efea7",
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      for (const key in activityContentProfiles) {
+        it(`returns true for ${key}`, () => {
+          expect(requireIsActivityContentProfile(activityContentProfiles[key])).toEqual(true);
+        });
+      }
+    });
+    describe("when the profile is invalid", () => {
+      [
+        {
+          name: "a profile undefined type field",
+          expErr: "invalid ActivityContentProfile type",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            name: "🌹🚗",
+          },
+        },
+        {
+          name: "a profile with a bad type field",
+          expErr: "invalid ActivityContentProfile type",
+          testObject: {
+            type: "Profil",
+            "@context": "https://www.w3.org/ns/activitystreams",
+            name: "🌹🚗",
+          },
+        },
+        {
+          name: "a profile with bad summary",
+          expErr: "ActivityContentProfile summary is not a string",
+          testObject: {
+            type: "Profile",
+            "@context": "https://www.w3.org/ns/activitystreams",
+            name: "🌹🚗",
+            summary: 12345,
+          },
+        },
+        {
+          name: "a profile with icon without a hash",
+          expErr: "ActivityContentImageLink hash is invalid",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Profile",
+            name: "dril",
+            icon: [
               {
-                algorithm: "keccak256",
-                value: "0x00a63eb58f6ce7fccd93e2d004fed81da5ec1a9747b63f5f1bf80742026efea7",
+                type: "Link",
+                mediaType: "image/jpg",
+                href: "https://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
               },
             ],
           },
-        ],
-      },
-    };
-
-    for (const key in activityContentProfiles) {
-      it(`returns true for ${key}`, () => {
-        expect(isActivityContentProfile(activityContentProfiles[key])).toEqual(true);
-      });
-    }
-
-    const notActivityContentProfiles: Record<string, unknown> = {
-      "a profile object without type": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        name: "🌹🚗",
-      },
-      "a profile object with icon without a hash": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Profile",
-        name: "dril",
-        icon: [
-          {
-            type: "Link",
-            href: "https://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
+        },
+        {
+          name: "a profile with bad icon",
+          expErr: "ActivityContentProfile icon is invalid",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Profile",
+            name: "dril",
+            icon: "http://placekitten.com/700/400",
           },
-        ],
-      },
-    };
-
-    for (const key in notActivityContentProfiles) {
-      it(`returns false for ${key}`, () => {
-        expect(isActivityContentProfile(notActivityContentProfiles[key])).toEqual(false);
+        },
+      ].forEach((testCase) => {
+        it(`returns false for ${testCase.name}`, () => {
+          expect(() => requireIsActivityContentProfile(testCase.testObject)).toThrowError(
+            "DSNPError: Invalid ActivityContent: " + testCase.expErr
+          );
+        });
       });
-    }
+    });
   });
-
   describe("isValidActivityContentNote", () => {
     describe("when the Note is valid", () => {
       const validActivityContentNotes: Record<string, ActivityContentNote> = {
@@ -494,8 +536,8 @@ describe("activity content validations", () => {
       };
 
       for (const key in validActivityContentNotes) {
-        it(`Does not throw an error for ${key}`, () => {
-          expect(() => requireValidActivityContentNote(validActivityContentNotes[key])).not.toThrowError();
+        it(`Returns true for ${key}`, () => {
+          expect(() => requireValidActivityContentNote(validActivityContentNotes[key])).toBeTruthy();
         });
       }
     });
@@ -503,19 +545,25 @@ describe("activity content validations", () => {
     describe("when the Note is invalid", () => {
       [
         {
-          name: "a note with a bad published field",
-          expErr: "published is invalid",
+          name: "a note with a bad published 'value' field",
+          expErr: "ActivityContentNote published is invalid",
           note: {
+            published: "Yesterday",
             "@context": "https://www.w3.org/ns/activitystreams",
             type: "Note",
             content: "Hello world!",
             mediaType: "text/plain",
-            published: "Yesterday",
+            hash: [
+              {
+                algorithm: "keccak256",
+                value: "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5",
+              },
+            ],
           },
         },
         {
           name: "a note with an audio attachment with an invalid hash",
-          expErr: "published is invalid",
+          expErr: "ActivityContentHash value is invalid",
 
           note: {
             "@context": "https://www.w3.org/ns/activitystreams",
@@ -543,8 +591,8 @@ describe("activity content validations", () => {
           },
         },
         {
-          name: "a note with an image attachment without a keccak256 hash",
-          expErr: "published is invalid",
+          name: "a note with an image attachment with an unsupported hash algorithm",
+          expErr: "ActivityContentHash has unsupported algorithm",
           note: {
             "@context": "https://www.w3.org/ns/activitystreams",
             type: "Note",
@@ -556,7 +604,7 @@ describe("activity content validations", () => {
                 url: [
                   {
                     type: "Link",
-                    href: "ftp://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
+                    href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
                     mediaType: "image/jpg",
                     hash: [
                       {
@@ -571,8 +619,8 @@ describe("activity content validations", () => {
           },
         },
         {
-          name: "a note with an video attachment without a supported mediaType",
-          expErr: "published is invalid",
+          name: "a note with an video attachment with an unsupported mediaType",
+          expErr: "ActivityContentVideo url mediaType is unsupported",
           note: {
             "@context": "https://www.w3.org/ns/activitystreams",
             type: "Note",
@@ -600,7 +648,7 @@ describe("activity content validations", () => {
         },
         {
           name: "a note with a link attachment with an invalid protocol",
-          expErr: "published is invalid",
+          expErr: "ActivityContentLink href protocol must be one of: http:, https:",
           note: {
             "@context": "https://www.w3.org/ns/activitystreams",
             type: "Note",
@@ -615,109 +663,142 @@ describe("activity content validations", () => {
           },
         },
         {
-          name: "with a location that is not an array",
+          name: "with a location that is not a record",
+          expErr: "ActivityContentLocation is not a record",
           note: {
+            location: "bad",
             "@context": "https://www.w3.org/ns/activitystreams",
             type: "Note",
             content: "Interesting project!",
             mediaType: "text/plain",
-            location: "bad",
+          },
+        },
+        {
+          name: "with a location object that is not a valid Location Type",
+          expErr: "ActivityContentLocation type is not 'Place'",
+          note: {
+            location: {
+              type: "bad",
+              name: "This is fine",
+            },
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "Interesting project!",
+            mediaType: "text/plain",
           },
         },
       ].forEach((testCase) => {
         it(`throws an error for ${testCase.name}`, () => {
-          expect(() => requireValidActivityContentNote(testCase.note)).toThrowError();
+          expect(() => requireValidActivityContentNote(testCase.note)).toThrowError(
+            "DSNPError: Invalid ActivityContent: " + testCase.expErr
+          );
         });
       });
     });
   });
-
   describe("isValidActivityContentProfile", () => {
-    const validActivityContentProfiles: Record<string, ActivityContentProfile> = {
-      "a profile object": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Profile",
-        name: "🌹🚗",
-      },
-      "a profile object with a published timestamp": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Profile",
-        name: "jaboukie",
-        published: "2000-01-01T00:00:00+00:00",
-      },
-      "a profile object with icon": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Profile",
-        name: "dril",
-        icon: [
-          {
-            type: "Link",
-            href: "https://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
-            mediaType: "image/jpg",
-            hash: [
+    describe("when profile is valid", () => {
+      const validActivityContentProfiles: Record<string, ActivityContentProfile> = {
+        "a profile object": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Profile",
+          name: "🌹🚗",
+        },
+        "a profile object with a published timestamp": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Profile",
+          name: "jaboukie",
+          published: "2000-01-01T00:00:00+00:00",
+        },
+        "a profile object with icon": {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          type: "Profile",
+          name: "dril",
+          icon: [
+            {
+              type: "Link",
+              href: "https://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
+              mediaType: "image/jpg",
+              hash: [
+                {
+                  algorithm: "keccak256",
+                  value: "0x00a63eb58f6ce7fccd93e2d004fed81da5ec1a9747b63f5f1bf80742026efea7",
+                },
+              ],
+            },
+          ],
+        },
+      };
+      for (const key in validActivityContentProfiles) {
+        it(`returns true for ${key}`, () => {
+          expect(() => requireValidActivityContentProfile(validActivityContentProfiles[key])).not.toThrow();
+        });
+      }
+    });
+
+    describe("when profile is invalid", () => {
+      [
+        {
+          name: "a profile object with an invalid published timestamp",
+          expErr: "ActivityContentProfile published is invalid",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Profile",
+            name: "jaboukie",
+            published: "07/28/2021",
+          },
+        },
+        {
+          name: "a profile object with an icon with an invalid hash",
+          expErr: "ActivityContentHash value is invalid",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Profile",
+            name: "dril",
+            icon: [
               {
-                algorithm: "keccak256",
-                value: "0x00a63eb58f6ce7fccd93e2d004fed81da5ec1a9747b63f5f1bf80742026efea7",
+                type: "Link",
+                mediaType: "image/jpg",
+                href: "https://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
+                hash: [
+                  {
+                    algorithm: "keccak256",
+                    value: "0x0",
+                  },
+                ],
               },
             ],
           },
-        ],
-      },
-    };
-
-    for (const key in validActivityContentProfiles) {
-      it(`returns true for ${key}`, () => {
-        expect(isValidActivityContentProfile(validActivityContentProfiles[key])).toEqual(true);
+        },
+        {
+          name: "a profile object with an icon with an unsupported hash algorithm",
+          expErr: "ActivityContentHash has unsupported algorithm",
+          testObject: {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Profile",
+            name: "dril",
+            icon: [
+              {
+                type: "Link",
+                mediaType: "image/jpg",
+                href: "https://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
+                hash: [
+                  {
+                    algorithm: "MD5",
+                    value: "0x00a63eb58f6ce7fccd93e2d004fed81da5ec1a9747b63f5f1bf80742026efea7",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ].forEach((testCase) => {
+        it(`returns false for ${testCase.name}`, () => {
+          expect(() => requireValidActivityContentProfile(testCase.testObject)).toThrowError(
+            "DSNPError: Invalid ActivityContent: " + testCase.expErr
+          );
+        });
       });
-    }
-
-    const invalidActivityContentProfiles: Record<string, unknown> = {
-      "a profile object with an invalid published timestamp": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Profile",
-        name: "jaboukie",
-        published: "07/28/2021",
-      },
-      "a profile object with an icon with an invalid hash": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Profile",
-        name: "dril",
-        icon: [
-          {
-            type: "Link",
-            href: "https://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
-            hash: [
-              {
-                algorithm: "keccak256",
-                value: "0x0",
-              },
-            ],
-          },
-        ],
-      },
-      "a profile object with an icon without a keccak256 hash": {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        type: "Profile",
-        name: "dril",
-        icon: [
-          {
-            type: "Link",
-            href: "https://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
-            hash: [
-              {
-                algorithm: "MD5",
-                value: "0x0",
-              },
-            ],
-          },
-        ],
-      },
-    };
-
-    for (const key in invalidActivityContentProfiles) {
-      it(`returns false for ${key}`, () => {
-        expect(isValidActivityContentProfile(invalidActivityContentProfiles[key])).toEqual(false);
-      });
-    }
+    });
   });
 });

--- a/src/core/activityContent/validation.test.ts
+++ b/src/core/activityContent/validation.test.ts
@@ -1,7 +1,7 @@
 import { ActivityContentAttachment, ActivityContentNote, ActivityContentProfile } from "./factories";
 import {
   requireActivityContentNoteType,
-  requireIsActivityContentProfileType,
+  requireActivityContentProfileType,
   requireValidActivityContentNote,
   requireValidActivityContentProfile,
   requireGetSupportedContentAttachments,
@@ -91,7 +91,7 @@ describe("activity content validations", () => {
       };
       for (const tc in testCases) {
         it(`returns the attachment ${tc}`, () => {
-          expect(requireGetSupportedContentAttachments(testCases[tc])).toEqual(testCases[tc]);
+          expect(requireGetSupportedContentAttachments(testCases[tc])).toStrictEqual(testCases[tc]);
         });
       }
     });
@@ -224,7 +224,7 @@ describe("activity content validations", () => {
           ],
         },
       ].forEach((testCase) => {
-        it(`${testCase.name} throws error`, () => {
+        it(`${testCase.name} throws expected error`, () => {
           expect(() => requireGetSupportedContentAttachments(testCase.attachment)).toThrowError(testCase.expErr);
         });
       });
@@ -254,7 +254,7 @@ describe("activity content validations", () => {
       });
 
       it("with one attachment that has multiple urls where only one is valid, returns the attachment", () => {
-        const multipleUrls = [
+        const multipleUrlsAttachment = [
           {
             type: "Image",
             url: [
@@ -294,7 +294,7 @@ describe("activity content validations", () => {
             ],
           },
         ];
-        expect(requireGetSupportedContentAttachments(multipleUrls)).toHaveLength(1);
+        expect(requireGetSupportedContentAttachments(multipleUrlsAttachment)).toStrictEqual(multipleUrlsAttachment);
       });
 
       it("with multiple attachments but only one is usable/valid, returns the valid one", () => {
@@ -629,7 +629,7 @@ describe("activity content validations", () => {
 
       for (const key in activityContentProfiles) {
         it(`returns true for ${key}`, () => {
-          expect(requireIsActivityContentProfileType(activityContentProfiles[key])).toEqual(true);
+          expect(requireActivityContentProfileType(activityContentProfiles[key])).toEqual(true);
         });
       }
     });
@@ -750,7 +750,7 @@ describe("activity content validations", () => {
         },
       ].forEach((testCase) => {
         it(`throws error for ${testCase.name}`, () => {
-          expect(() => requireIsActivityContentProfileType(testCase.testObject)).toThrowError(
+          expect(() => requireActivityContentProfileType(testCase.testObject)).toThrowError(
             "DSNPError: Invalid ActivityContent: " + testCase.expErr
           );
         });

--- a/src/core/activityContent/validation.ts
+++ b/src/core/activityContent/validation.ts
@@ -214,7 +214,7 @@ const requireIsActivityContentLocation = (obj: unknown): obj is ActivityContentL
 
 const requireIsActivityContentTag = (obj: unknown): obj is ActivityContentTag => {
   if (!isRecord(obj)) throw new InvalidActivityContentError(invalidRecordMessage("ActivityContentTag"));
-  if (obj["type"] && obj["type"] === "Mention") {
+  if (obj["type"] === "Mention") {
     return requireIsActivityContentMention(obj);
   }
   return requireIsActivityContentHashtag(obj);

--- a/src/core/activityContent/validation.ts
+++ b/src/core/activityContent/validation.ts
@@ -338,6 +338,24 @@ export const requireIsActivityContentNoteType = (obj: unknown): obj is ActivityC
 };
 
 /**
+ * isActivityContentNoteType is a non-throwing version of `requireIsActivityContentNoteType`
+ * Performs the same checks but catches InvalidActivityContentError and returns false instead.
+ *
+ * @param obj - The object to check
+ * @returns a boolean - indicating if the object is an ActivityContentNote
+ */
+export const isActivityContentNoteType = (obj: unknown): obj is ActivityContentNote => {
+  if (!isRecord(obj)) return false;
+  try {
+    requireIsActivityContentNoteType(obj);
+  } catch (e) {
+    if (e instanceof InvalidActivityContentError) return false;
+    throw e;
+  }
+  return true;
+};
+
+/**
  * requireIsActivityContentProfileType() is a type check function for
  * ActivityContentProfile objects. Note that this function only checks that the
  * given object meets the first-level type definition of an ActivityContentProfile. It
@@ -346,7 +364,7 @@ export const requireIsActivityContentNoteType = (obj: unknown): obj is ActivityC
  * image format.
  *
  * @param obj - The object to check
- * @returns A boolean indicating whether or not the object is an ActivityContentProfile
+ * @returns true if the object is an ActivityContentProfile,otherwise throws an Error
  * @throws InvalidActivityContentError if type checks fail.
  */
 export const requireIsActivityContentProfileType = (obj: unknown): obj is ActivityContentProfile => {
@@ -356,6 +374,24 @@ export const requireIsActivityContentProfileType = (obj: unknown): obj is Activi
   if (obj["icon"] && !isArrayOfType(obj["icon"], requireIsActivityContentImageLink))
     throw new InvalidActivityContentError("ActivityContentProfile icon is invalid");
   if (obj["attachment"]) requireToArray(obj["attachment"], "ActivityContentProfile attachment");
+  return true;
+};
+
+/**
+ * isActivityContentProfileType is a non-throwing version of `requireIsActivityContentProfileType`.
+ * Performs the same checks but catches InvalidActivityContentError and returns false instead.
+ *
+ * @param obj - The object to check
+ * @returns a boolean - indicating if the object is an ActivityContentProfile
+ */
+export const isActivityContentProfileType = (obj: unknown): obj is ActivityContentProfile => {
+  if (!isRecord(obj)) return false;
+  try {
+    requireIsActivityContentProfileType(obj);
+  } catch (e) {
+    if (e instanceof InvalidActivityContentError) return false;
+    throw e;
+  }
   return true;
 };
 

--- a/src/core/activityContent/validation.ts
+++ b/src/core/activityContent/validation.ts
@@ -358,7 +358,7 @@ export const requireIsActivityContentProfileType = (obj: unknown): obj is Activi
  * If there are attachments but none of them are valid, it throws an error.
  *
  * @param obj - an array of unknown object types to check for validity
- * @returns an array of all valid attachments
+ * @returns an array of all valid ActivityContentAttachments
  */
 export const requireGetSupportedContentAttachments = (obj: Array<unknown>): Array<ActivityContentAttachment> => {
   if (!obj.length) return [];

--- a/src/core/activityContent/validation.ts
+++ b/src/core/activityContent/validation.ts
@@ -28,7 +28,7 @@ import { InvalidActivityContentError } from "./errors";
  */
 const ISO8601_REGEX = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d{1,})?(Z|[+-][01][0-9]:[0-5][0-9])?$/;
 const HREF_REGEX = /^https?:\/\/.+/;
-const DURATION_REGEX = /^-?P[0-9]+Y?([0-9]+M)?([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+(\.[0-9]+)?S)?)?$/;
+const DURATION_REGEX = /^-?P([0-9]+Y)?([0-9]+M)?([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+(\.[0-9]+)?S)?)?$/;
 const HASH_REGEX = /^0x[0-9A-Fa-f]{64}$/;
 const SUPPORTED_ALGORITHMS = ["keccak256"];
 const SUPPORTED_AUDIO_MEDIA_TYPES = ["audio/mp3", "audio/ogg", "audio/webm"];
@@ -383,7 +383,7 @@ export const requireGetSupportedContentAttachments = (obj: Array<unknown>): Arra
  * @param obj - The object to check
  * @returns true if valid, throws Error if invalid.
  */
-export const requireValidActivityContentNote = (obj: unknown): void => {
+export const requireValidActivityContentNote = (obj: unknown): boolean => {
   if (requireActivityContentNoteType(obj)) {
     if (obj["tag"]) requireIsActivityContentTag(obj["tag"]);
 
@@ -397,6 +397,7 @@ export const requireValidActivityContentNote = (obj: unknown): void => {
   } else {
     throw new InvalidActivityContentError("ActivityContentNote is invalid for an unknown reason");
   }
+  return true;
 };
 
 /**
@@ -407,9 +408,9 @@ export const requireValidActivityContentNote = (obj: unknown): void => {
  * hashes are correct.
  *
  * @param obj - The object to check
- * @returns A boolean indicating whether or not the object is a valid ActivityContentProfile
+ * @returns true if valid, throws Error if invalid.
  */
-export const requireValidActivityContentProfile = (obj: unknown): void => {
+export const requireValidActivityContentProfile = (obj: unknown): boolean => {
   if (requireIsActivityContentProfileType(obj)) {
     if (obj["tag"] && !isArrayOfType(obj["tag"], requireIsActivityContentTag)) requireIsActivityContentTag(obj["tag"]);
 
@@ -424,4 +425,5 @@ export const requireValidActivityContentProfile = (obj: unknown): void => {
   } else {
     throw new InvalidActivityContentError("ActivityContentProfile is invalid for an unknown reason");
   }
+  return true;
 };

--- a/src/core/activityContent/validation.ts
+++ b/src/core/activityContent/validation.ts
@@ -361,12 +361,24 @@ export const requireIsActivityContentProfileType = (obj: unknown): obj is Activi
 
 /**
  * requireGetSupportedContentAttachments iterates over the provided list and returns
- * the valid attachments. If the passed in obj is empty, returns an empty array.
- * If there are attachments but none of them are valid, it throws an error.
+ * the valid+supported attachments. If the passed in obj is empty, returns an empty array.
+ * If there are attachments but none of them are valid+supported, it throws an error.
+ * Attachments MUST first pass a type check to be considered valid at all.
  *
  * @param obj - an array of unknown object types to check for validity
  * @returns an array of all valid ActivityContentAttachments
- * @throws InvalidActivityContentError if there are no valid attachments.
+ * @throws InvalidActivityContentError if there are no valid attachments with
+ * supported Link attachments.
+ *
+ * Examples:
+ * 1. One Image attachment with one URL that points to a TIFF file throws an error.
+ * 2. One Image attachment with two URLs, one that is a TIFF and the other is JPG,
+ *    does not throw.
+ * 3. One Image attachment with two URLs, both are JPG, but one has a malformed
+ *    hash of 0xdeadbeef (it's too short), throws an error due to failing
+ *    the type check.
+ * 4. Two Image attachments, the one from #2 and the one from #3, does NOT throw and
+ *    returns just #2.
  */
 export const requireGetSupportedContentAttachments = (obj: Array<unknown>): Array<ActivityContentAttachment> => {
   if (!obj.length) return [];


### PR DESCRIPTION
Problem
=======
We need more informative errors.
[Fixes #179106793](https://www.pivotaltracker.com/story/show/179106793)

Solution
========
Since the only entry points to the validations threw an error if the ActivityContent(Note|Profile) was invalid, almost everything now throws an error if it doesn't validate, however, sometimes we only need one item of a list to be valid, in particular, attachments.  Attachment validation has been abstracted.

1. Anything that throws an error when something is not valid has been renamed to `requireFoo`
1. Functions that do simple type checking without validating contents should end with `Type`
1. If an attachment has multiple URLs, only one need be valid.  The following examples would be valid:
    1. One url has only unsupported hash algorithms - MD5 + secp256k1, but the other has keccak256 which is supported.
    1. One url href  is `ftp` but the other is `https` 
1. If a Note or Profile has multiple attachments, only one need be valid. The following examples would be valid:
    1. Two image attachments: one has only a url pointing to a HEIC (unsupported) and the other points to a JPEG (supported)
    2. Two image attachments:  one points to an FTP URL (unsupported) and the other is an HTTPS URL (supported).
1. A Note or Profile can have an empty attachments array and be valid, but if it doesn't, and _none_ are valid, we rerun our validations without catching errors and throw the first one.  Example:   An Image attachment for a Note has only an FTP url, the validation will throw an `InvalidActivityContentError` saying `ActivityContentLink href is invalid`.
1. The new function that is used above,  `requireGetSupportedContentAttachments` is also exported for use by SDK developers to assist in debugging or simply to get a list of all the attachments valid for DSNP.
1. In order to do the above, on the first pass, though attachment validations throw errors, they are caught and logged to console, for ease of debugging.

Error/return value behavior isn't 100% consistent; there's too much going on and needs are different depending on the object's depth.

with @rosalinekarr 

Double Checks:
---------------
- [x] Did you update the changelog?
- [x] Any new modules need to be exported?  NO
- [x] Are new methods in the right module?
- [x] N/AAre new methods/modules in core or not (i.e. porcelain or plumbing)?
- [x] Do you have good documentation on exported methods?

Change summary:
---------------
* Rework and rename validators to throw or log informative errors when an `ActivityContent` is invalid
* Redo tests to reflect changes, add more to improve test coverage
* Fix a bug in `DURATION_REGEX` 

Steps to Verify:
----------------
* Please help by reviewing for consistent naming.
* All tests should pass -- see test coverage
* There are tests for as many potential error cases (modulo being in different attachments), so if you think of one I've left out please comment.
