### PR TITLE
Ensure we fetch registrations using Ethereum checksum address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+Fix bug in `getRegistrationsByWalletAddress` by normalizing address to checksum version 
 
 ## [2.0.2] - 2021-08-11
 ### Added

--- a/src/core/contracts/identity.ts
+++ b/src/core/contracts/identity.ts
@@ -422,7 +422,7 @@ export const resolveDelegatesFor = async (
 
   const filteredDelegateLogData = lastLogForIdentityAddress.filter((delegate: DelegateLogData) => {
     return (
-      delegate.delegate == ethereumAddress &&
+      delegate.delegate.toLowerCase() == ethereumAddress.toLowerCase() &&
       (isDelegateAddLogData(delegate) || (isDelegateRemoveLogData(delegate) && !isRemoved(delegate)))
     );
   });

--- a/src/core/contracts/registry.ts
+++ b/src/core/contracts/registry.ts
@@ -279,8 +279,8 @@ const getLatestRegistryUpdatesFor = async (identityAddress: HexString): Promise<
  * @returns A list of registrations that are associated to the address
  */
 export const getRegistrationsByWalletAddress = async (walletAddress: EthereumAddress): Promise<Registration[]> => {
-  const identityAddresses: EthereumAddress[] = await getDelegateIdentitiesFor(walletAddress);
-
+  const canonicalAddress = ethers.utils.getAddress(walletAddress);
+  const identityAddresses: EthereumAddress[] = await getDelegateIdentitiesFor(canonicalAddress);
   const registrations: Registration[][] = await Promise.all(
     identityAddresses.map((identityAddresses) => getRegistrationsByIdentityAddress(identityAddresses))
   );

--- a/src/core/contracts/registry.ts
+++ b/src/core/contracts/registry.ts
@@ -279,8 +279,8 @@ const getLatestRegistryUpdatesFor = async (identityAddress: HexString): Promise<
  * @returns A list of registrations that are associated to the address
  */
 export const getRegistrationsByWalletAddress = async (walletAddress: EthereumAddress): Promise<Registration[]> => {
-  const canonicalAddress = ethers.utils.getAddress(walletAddress);
-  const identityAddresses: EthereumAddress[] = await getDelegateIdentitiesFor(canonicalAddress);
+  const identityAddresses: EthereumAddress[] = await getDelegateIdentitiesFor(walletAddress);
+
   const registrations: Registration[][] = await Promise.all(
     identityAddresses.map((identityAddresses) => getRegistrationsByIdentityAddress(identityAddresses))
   );


### PR DESCRIPTION
Problem
=======
There was a bug whereby if we passed in the regular Ethereum address, fetching registrations would fail because it's expecting the checksummed version. 

Kind of [part of #178933068](https://www.pivotaltracker.com/story/show/178933068)

Solution
========
Call ethers.utils.getAddress to ensure we use checksum address version in `getRegistrationsByWalletAddress` to ensure we provide the correct version of the address.
with @wilwade , @acruikshank 

Double Checks:
---------------
- [x] Did you update the changelog?
- [x] N/A Any new modules need to be exported?
- [x] N/A Are new methods in the right module?
- [x] N/A Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [x] N/A Do you have good documentation on exported methods?

Change summary:
---------------
* Ensure we fetch registrations using Ethereum checksum address in getRegistrationsByWalletAddress
* Update changelog

Steps to Verify:
----------------
Tests should all pass.
If you run a local hardhat node and deploy contracts, the following test code output the registration twice:
```javascript
import {ethers} from "ethers";
import * as sdk from "@dsnp/sdk";

const main = async () => {
  const providerUrl = "http://localhost:8545"

  const account = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
  const accountAlt = "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720"

  const pk = "0xdf57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e"
  const provider = new ethers.providers.JsonRpcProvider(providerUrl);
  const signer = new ethers.Wallet(pk, provider);


  sdk.setConfig({provider, signer})
  const res = await sdk.handles.createRegistration(account, "tomasina")
  console.log({res})

  const result = await sdk.core.contracts.registry.getRegistrationsByWalletAddress(account)
  console.log({result})

  const resultAlt = await sdk.core.contracts.registry.getRegistrationsByWalletAddress(accountAlt)
  console.log({resultAlt})
}

main();
```