### PR TITLE
Fixed bug in sdk/core/contracts/publisher#dsnpBatchFilter()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - sdk.core.contracts.publisher.dsnpBatchFilter is no longer async
 - Updated Ethers from 5.3.0 -> 5.4.4
 
+### Fixed
+- Fixed bug resulting in incorrect output from sdk.core.contracts.publisher.dsnpBatchFilter when passed Tombstone
+
 ## [2.0.1] - 2021-08-04
 ### Changes
 - Updated registry.resolveRegistration to support not found cases for nodes that do not return a failure reason.

--- a/src/core/contracts/publisher.test.ts
+++ b/src/core/contracts/publisher.test.ts
@@ -1,3 +1,4 @@
+import { AnnouncementType } from "../announcements";
 import { publish, Publication, dsnpBatchFilter } from "./publisher";
 import { hash } from "../utilities";
 import { setupConfig } from "../../test/sdkTestConfig";
@@ -32,9 +33,16 @@ describe("#batch", () => {
     });
 
     it("can return the topics with a type filter", () => {
-      expect(dsnpBatchFilter(1).topics).toEqual([
+      expect(dsnpBatchFilter(AnnouncementType.GraphChange).topics).toEqual([
         "0xe63a4904ccacc079f71e52aad2cf99c00a7d4963566562a94d7c07610f1df576",
         "0x0000000000000000000000000000000000000000000000000000000000000001",
+      ]);
+    });
+
+    it("can return the correct topics for Tombstones", () => {
+      expect(dsnpBatchFilter(AnnouncementType.Tombstone).topics).toEqual([
+        "0xe63a4904ccacc079f71e52aad2cf99c00a7d4963566562a94d7c07610f1df576",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
       ]);
     });
   });

--- a/src/core/contracts/publisher.ts
+++ b/src/core/contracts/publisher.ts
@@ -43,7 +43,7 @@ export const dsnpBatchFilter = (announcementType?: AnnouncementType): EventFilte
     publisherInterface.events["DSNPBatchPublication(int16,bytes32,string)"]
   );
   const topics = [topic];
-  if (announcementType) {
+  if (announcementType !== undefined) {
     topics.push("0x" + announcementType.toString(16).padStart(64, "0"));
   }
   return { topics };


### PR DESCRIPTION
Problem
=======
`dsnpBatchFilter()` in `sdk/core/contracts/publisher` fails to output the correct result for `AnnouncementType.Tombstone` due to JavaScript type coercion nonsense
[#178901784](https://www.pivotaltracker.com/story/show/178901784)

Solution
========
Changed `dsnpBatchFilter()` to work properly for `AnnouncementType.Tombstone`.

Change summary:
---------------
* Changed condition in `dsnpBatchFilter()` to check undefined instead of falsey-ness
* Added test to prevent bug in future
