### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+
+## [2.1.0] - 2021-08-16
 ### Added
 - sdk.core.identifiers.convertDSNPUserIdOrURIToBigNumber supports non-0x prefixed strings
 - sdk.core.utilities.serializeToHex for predictable hexadecimal to string values

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dsnp/sdk",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dsnp/sdk",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dsnp/contracts": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsnp/sdk",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "SDK Library for the DSNP",
   "type": "commonjs",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
## [2.1.0] - 2021-08-16
### Added
- sdk.core.identifiers.convertDSNPUserIdOrURIToBigNumber supports non-0x prefixed strings
- sdk.core.utilities.serializeToHex for predictable hexadecimal to string values
- Added createTombstone factory to announcements module
- Added isTombstoneAnnouncement validator to announcements module
- Added tombstone porcelain method to top level exports

### Changed
- Major rework of ActivityContent validations to log or throw informative errors when an ActivityContent is invalid, with a couple of other changes:
  - An array of locations is no longer allowed; this will invalidate an attachment.
  - Attachments MUST pass a minimal type check before further processing. For example if even one of its Link url hashes is _malformed_, it fails validation.
  - If an attachment passes a type check, but it fails to meet requirements for what is supported by DSNP, it also fails validation. HOWEVER, attachments can have multiple Link URLs; only one needs to be supported by DSNP to be considered a valid attachment. See code documentation for details.
  - If there is more than one attachment, but at least one is valid, it's considered a valid ActivityContent.
  - New exported function for retrieving an array of valid attachments for an ActivityContent: `requireGetSupportedContentAttachments`  Please see code documentation for details.
  - Note on naming convention: anything beginning with 'require' will throw when failing the indicated action or validation. For example `requireGetSupportedContentAttachments` throws an error if there are attachments but none are valid.
  - If you wish to simply check for type validity without having to catch errors, use `isActivityContentNoteType` and `isActivityContentProfileType` 
- Fixed a bug in duration validation.
- Reworked ActivityContent validations to log or throw informative errors when an ActivityContent is invalid. 

### Fixed
- Fixed bug resulting in incorrect output from sdk.core.contracts.publisher.dsnpBatchFilter when passed Tombstone
- Fixed a bug in duration validation.
- Fixed a bug in DURATION_REGEX.
- Fix bug in `getRegistrationsByWalletAddress` by normalizing address to checksum version