### PR TITLE
add objectid to graphchange parquet schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- Fixed bug where graph change annoucements stored in parquet batch files would drop their `objectId` field.
+
 ## [2.1.0] - 2021-08-16
 ### Added
 - sdk.core.identifiers.convertDSNPUserIdOrURIToBigNumber supports non-0x prefixed strings

--- a/src/core/batch/parquetSchema.test.ts
+++ b/src/core/batch/parquetSchema.test.ts
@@ -9,6 +9,7 @@ describe("#getSchemaFor", () => {
       changeType: { type: "INT32" },
       announcementType: { type: "INT32" },
       fromId: { type: "BYTE_ARRAY" },
+      objectId: { type: "BYTE_ARRAY" },
       signature: { type: "BYTE_ARRAY" },
       createdAt: { type: "INT64" },
     });

--- a/src/core/batch/parquetSchema.ts
+++ b/src/core/batch/parquetSchema.ts
@@ -70,6 +70,7 @@ export const ReplyBloomFilterOptions = {
 export const GraphChangeSchema = {
   announcementType: { type: "INT32" },
   fromId: { type: "BYTE_ARRAY" },
+  objectId: { type: "BYTE_ARRAY" },
   changeType: { type: "INT32" },
   signature: { type: "BYTE_ARRAY" },
   createdAt: { type: "INT64" },


### PR DESCRIPTION
Problem
=======
The objectId (i.e. the followee or unfollowee) of a graph change announcement is missing from the output when reading from a parquet batch created with the SDK. It turns out this field is never written to the file.

Solution
========
Add `objectId` to the parquet schema for graph change announcements.

Double Checks:
---------------
- [X] Did you update the changelog?
- [X] Any new modules need to be exported?
- [X] Are new methods in the right module?
- [X] Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [X] Do you have good documentation on exported methods?

Change summary:
---------------
* Add `objectId` to `GraphChangeSchema`
* Also add `objectId` to `GraphChangeSchema` test.

Steps to Verify:
----------------
1. Write a GraphChange annoucement to a batch file.
1. Either inspect the file directly or read its contents.
1. Note that it contains data for the `objectId`.
