### PR TITLE
Bugs/invalid validators 179299754

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Changed AnnouncementWithSignature to take an AnnouncementType instead of a TypedAnnouncement
 - Changed to use bigint for types instead of BigInt
 
+### Fixed
+- Changed isValidAnnouncement to return false for all announcements missing a createdAt big int
+
 ## [2.1.1] - 2021-08-17
 ### Changed
 - Updated dependencies

--- a/src/core/announcements/validation.test.ts
+++ b/src/core/announcements/validation.test.ts
@@ -91,7 +91,7 @@ describe("validation", () => {
 
       it("returns false for graph change announcements without createdAt", async () => {
         const announcement = createFollowGraphChange(userId, followeeId);
-        announcement["createdAt"] = undefined as unknown as BigInt;
+        announcement["createdAt"] = undefined as unknown as bigint;
         const signedAnnouncement = await sign(announcement as unknown as Announcement);
 
         expect(await isValidAnnouncement(signedAnnouncement)).toEqual(false);
@@ -134,7 +134,7 @@ describe("validation", () => {
           AnnouncementType.Broadcast,
           "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01"
         );
-        announcement["createdAt"] = undefined as unknown as BigInt;
+        announcement["createdAt"] = undefined as unknown as bigint;
         const signedAnnouncement = await sign(announcement);
 
         await expect(isValidAnnouncement(signedAnnouncement)).rejects.toThrow(AnnouncementError);
@@ -159,7 +159,7 @@ describe("validation", () => {
           "https://fakeurl.org",
           "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
         );
-        announcement["createdAt"] = undefined as unknown as BigInt;
+        announcement["createdAt"] = undefined as unknown as bigint;
         const signedAnnouncement = await sign(announcement);
 
         expect(await isValidAnnouncement(signedAnnouncement)).toEqual(false);
@@ -186,7 +186,7 @@ describe("validation", () => {
           "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
           "dsnp://0x1234567/0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
         );
-        announcement["createdAt"] = undefined as unknown as BigInt;
+        announcement["createdAt"] = undefined as unknown as bigint;
         const signedAnnouncement = await sign(announcement);
 
         expect(await isValidAnnouncement(signedAnnouncement)).toEqual(false);
@@ -211,7 +211,7 @@ describe("validation", () => {
           "🎉",
           "dsnp://0x1234567/0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
         );
-        announcement["createdAt"] = undefined as unknown as BigInt;
+        announcement["createdAt"] = undefined as unknown as bigint;
         const signedAnnouncement = await sign(announcement);
 
         expect(await isValidAnnouncement(signedAnnouncement)).toEqual(false);
@@ -236,7 +236,7 @@ describe("validation", () => {
           "https://fakeurl.org",
           "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
         );
-        announcement["createdAt"] = undefined as unknown as BigInt;
+        announcement["createdAt"] = undefined as unknown as bigint;
         const signedAnnouncement = await sign(announcement);
 
         expect(await isValidAnnouncement(signedAnnouncement)).toEqual(false);

--- a/src/core/announcements/validation.ts
+++ b/src/core/announcements/validation.ts
@@ -114,6 +114,7 @@ export const isBroadcastAnnouncement = (obj: unknown): obj is BroadcastAnnouncem
   if (!isRecord(obj)) return false;
   if (obj["announcementType"] != AnnouncementType.Broadcast) return false;
   if (!isDSNPUserId(obj["fromId"])) return false;
+  if (!isBigInt(obj["createdAt"])) return false;
   if (!isString(obj["url"])) return false;
   if (!isString(obj["contentHash"])) return false;
 
@@ -130,6 +131,7 @@ export const isReplyAnnouncement = (obj: unknown): obj is ReplyAnnouncement => {
   if (!isRecord(obj)) return false;
   if (obj["announcementType"] != AnnouncementType.Reply) return false;
   if (!isDSNPUserId(obj["fromId"])) return false;
+  if (!isBigInt(obj["createdAt"])) return false;
   if (!isString(obj["url"])) return false;
   if (!isString(obj["contentHash"])) return false;
   if (!isDSNPAnnouncementURI(obj["inReplyTo"])) return false;
@@ -147,6 +149,7 @@ export const isReactionAnnouncement = (obj: unknown): obj is ReactionAnnouncemen
   if (!isRecord(obj)) return false;
   if (obj["announcementType"] != AnnouncementType.Reaction) return false;
   if (!isDSNPUserId(obj["fromId"])) return false;
+  if (!isBigInt(obj["createdAt"])) return false;
   if (!isValidEmoji(obj["emoji"])) return false;
   if (!isDSNPAnnouncementURI(obj["inReplyTo"])) return false;
 
@@ -163,6 +166,7 @@ export const isProfileAnnouncement = (obj: unknown): obj is ProfileAnnouncement 
   if (!isRecord(obj)) return false;
   if (obj["announcementType"] != AnnouncementType.Profile) return false;
   if (!isDSNPUserId(obj["fromId"])) return false;
+  if (!isBigInt(obj["createdAt"])) return false;
   if (!isString(obj["url"])) return false;
   if (!isString(obj["contentHash"])) return false;
 


### PR DESCRIPTION
Problem
=======
Announcement validators were incorrectly returning valid for announcements missing a `createdAt` field.
[#179299754](https://www.pivotaltracker.com/story/show/179299754)

Solution
========
Update the validators to require `createdAt` exist and be a `BigInt`

Change summary:
---------------
* Updated announcement validators to return false for announcements missing a `createdAt` field
* Added tests
