### PR TITLE
Bugs/is authed accepting signed 179299921

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Changed
 - BREAKING: Changed batch.readFile() to pass parsed announcements instead of parquet records to callback
 - BREAKING: Changed createdAt on announcements to BigInt instead of number
+- Changed isSignatureAuthorizedTo to work with SignedAnnouncements
+- Changed isSignatureAuthorizedTo to throw InvalidAnnouncementParameterError when passed an invalid object as announcement
 
 ## [2.1.1] - 2021-08-17
 ### Changed

--- a/src/core/announcements/index.ts
+++ b/src/core/announcements/index.ts
@@ -21,4 +21,5 @@ export * from "./errors";
 export * from "./factories";
 export * from "./crypto";
 export * from "./serialization";
+export * from "./services";
 export * from "./validation";

--- a/src/core/contracts/errors.ts
+++ b/src/core/contracts/errors.ts
@@ -47,3 +47,13 @@ export class NoLogsFoundContractError extends ContractError {
     this.eventName = eventName;
   }
 }
+
+/**
+ * InvalidAnnouncementParameterError indicates that something other than an
+ * announcement was passed as an announcement.
+ */
+export class InvalidAnnouncementParameterError extends ContractError {
+  constructor(announcement: unknown) {
+    super(`Invalid announcement parameter: ${announcement}.`);
+  }
+}

--- a/src/core/contracts/registry.test.ts
+++ b/src/core/contracts/registry.test.ts
@@ -1,5 +1,6 @@
 import { ethers, Signer } from "ethers";
 import { JsonRpcProvider } from "@ethersproject/providers";
+
 import { DSNPError } from "../errors";
 import { revertHardhat, snapshotHardhat, setupSnapshot } from "../../test/hardhatRPC";
 import {
@@ -16,7 +17,7 @@ import {
 import { Identity__factory } from "../../types/typechain";
 import { setupConfig } from "../../test/sdkTestConfig";
 import { Permission } from "./identity";
-import { Announcement, sign } from "../announcements";
+import { createBroadcast, Announcement, SignedAnnouncement, sign } from "../announcements";
 import { generateBroadcast } from "../../generators/dsnpGenerators";
 import {
   getSignerForAccount,
@@ -25,7 +26,7 @@ import {
   RegistrationWithSigner,
 } from "../../test/testAccounts";
 import { generateHexString } from "@dsnp/test-generators";
-import { DSNPUserURI } from "../identifiers";
+import { convertDSNPUserURIToDSNPUserId, DSNPUserURI } from "../identifiers";
 import { EthereumAddress } from "../../types/Strings";
 import { mineBlocks } from "../../test/utilities";
 
@@ -390,7 +391,8 @@ describe("registry", () => {
   });
 
   describe("validateMessage", () => {
-    const msg: Announcement = generateBroadcast();
+    let msg: Announcement;
+    let signedAnnouncement: SignedAnnouncement;
 
     const permAllowed = Permission.ANNOUNCE;
     const permDenied = Permission.OWNERSHIP_TRANSFER;
@@ -407,8 +409,13 @@ describe("registry", () => {
       contractAddr = identityContract.address;
       const tx = await register(contractAddr, "Animaniacs");
       dsnpUserURI = await getURIFromRegisterTransaction(tx);
-      const signedMessage = await sign(msg);
-      sig = signedMessage.signature;
+      msg = createBroadcast(
+        convertDSNPUserURIToDSNPUserId(dsnpUserURI),
+        "https://fakeurl.org",
+        "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+      );
+      signedAnnouncement = await sign(msg);
+      sig = signedAnnouncement.signature;
     });
 
     afterAll(async () => {
@@ -416,7 +423,11 @@ describe("registry", () => {
     });
 
     it("returns true if the signer is authorized for the given permissions", async () => {
-      await expect(isSignatureAuthorizedTo(sig, msg, dsnpUserURI, permAllowed)).toBeTruthy();
+      await expect(isSignatureAuthorizedTo(sig, msg, dsnpUserURI, permAllowed)).resolves.toBeTruthy();
+    });
+
+    it("returns true if provided a signed announcement", async () => {
+      await expect(isSignatureAuthorizedTo(sig, signedAnnouncement, dsnpUserURI, permAllowed)).resolves.toBeTruthy();
     });
 
     it("returns false if the signer is not authorized for the given permissions", async () => {

--- a/src/core/contracts/registry.test.ts
+++ b/src/core/contracts/registry.test.ts
@@ -2,6 +2,7 @@ import { ethers, Signer } from "ethers";
 import { JsonRpcProvider } from "@ethersproject/providers";
 
 import { DSNPError } from "../errors";
+import { InvalidAnnouncementParameterError } from "./errors";
 import { revertHardhat, snapshotHardhat, setupSnapshot } from "../../test/hardhatRPC";
 import {
   changeAddress,
@@ -428,6 +429,12 @@ describe("registry", () => {
 
     it("returns true if provided a signed announcement", async () => {
       await expect(isSignatureAuthorizedTo(sig, signedAnnouncement, dsnpUserURI, permAllowed)).resolves.toBeTruthy();
+    });
+
+    it("throws if provided an invalid object as an announcement", async () => {
+      await expect(isSignatureAuthorizedTo(sig, 3 as unknown as string, dsnpUserURI, permAllowed)).rejects.toThrow(
+        InvalidAnnouncementParameterError
+      );
     });
 
     it("returns false if the signer is not authorized for the given permissions", async () => {

--- a/src/core/contracts/registry.ts
+++ b/src/core/contracts/registry.ts
@@ -186,9 +186,9 @@ export const getDSNPRegistryUpdateEvents = async (
 };
 
 /**
- * isSignatureAuthorizedTo() validates a serialized message or announcement against a signature and then checks that the
- * signer has the permissions specified. Announcements should be passed as is,
- * without serializing, to guarantee consistent results.
+ * isSignatureAuthorizedTo() validates an announcement, either as a string, a
+ * SignedAnnouncement or unsigned Announcement, against a signature and then
+ * checks that the signer has the permissions specified.
  *
  * @throws {@link MissingProviderConfigError}
  * Thrown if the provider is not configured.
@@ -196,8 +196,10 @@ export const getDSNPRegistryUpdateEvents = async (
  * Thrown if a registration cannot be found for the given DSNP User URI.
  * @throws {@link MissingContractAddressError}
  * Thrown if the requested contract address cannot be found.
- * @param signature - the signature for the message
- * @param message - the signed announcement or string
+ * @throws {@link InvalidAnnouncementParameterError}
+ * Thrown if the announcement provided is invalid
+ * @param signature - the signature for the announcement
+ * @param announcement - the signed, unsigned or serialized announcement
  * @param dsnpUserURI - the DSNP User URI of the supposed signer
  * @param permission - the permissions to check for
  * @param blockTag - (optional). A block number or string BlockTag
@@ -207,7 +209,7 @@ export const getDSNPRegistryUpdateEvents = async (
  */
 export const isSignatureAuthorizedTo = async (
   signature: HexString,
-  message: SignedAnnouncement | Announcement | string,
+  announcement: SignedAnnouncement | Announcement | string,
   dsnpUserURI: DSNPUserURI,
   permission: Permission,
   blockTag?: ethers.providers.BlockTag,
@@ -231,14 +233,14 @@ export const isSignatureAuthorizedTo = async (
   }
 
   let signedString: string;
-  if (isString(message)) {
-    signedString = message;
-  } else if (isSignedAnnouncement(message)) {
-    signedString = serialize(convertSignedAnnouncementToAnnouncement(message));
-  } else if (isAnnouncement(message)) {
-    signedString = serialize(message);
+  if (isString(announcement)) {
+    signedString = announcement;
+  } else if (isSignedAnnouncement(announcement)) {
+    signedString = serialize(convertSignedAnnouncementToAnnouncement(announcement));
+  } else if (isAnnouncement(announcement)) {
+    signedString = serialize(announcement);
   } else {
-    throw new InvalidAnnouncementParameterError(message);
+    throw new InvalidAnnouncementParameterError(announcement);
   }
 
   const signerAddr = ethers.utils.verifyMessage(signedString, signature);


### PR DESCRIPTION
Problem
=======
`isSignatureAuthorizedTo` fails when passed a signed announcement
[#179299921](https://www.pivotaltracker.com/story/show/179299921)

Solution
========
Change `isSignatureAuthorizedTo` to accept announcements with signatures

Change summary:
---------------
* Changed `isSignatureAuthorizedTo` to work as expected when given a signed announcement
* Changed `isSignatureAuthorizedTo` to throw an error when given something other than a signed, unsigned or serialized announcement
