### PR TITLE
add logIndex and transactionIndex to subscription data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+### fixed
+- added `transactionIndex` and `logIndex` to batch and registry subcriptions
 
 ## Unreleased
 

--- a/src/core/contracts/identity.test.ts
+++ b/src/core/contracts/identity.test.ts
@@ -543,6 +543,8 @@ describe("identity", () => {
           delegate: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
           blockNumber: 330,
           transactionHash: expect.any(String),
+          transactionIndex: expect.any(Number),
+          logIndex: expect.any(Number),
         },
       ];
 
@@ -566,6 +568,8 @@ describe("identity", () => {
           delegate: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
           blockNumber: 330,
           transactionHash: expect.any(String),
+          transactionIndex: expect.any(Number),
+          logIndex: expect.any(Number),
         },
         {
           name: "DSNPRemoveDelegate",
@@ -574,6 +578,8 @@ describe("identity", () => {
           blockNumber: 331,
           endBlock: 400,
           transactionHash: expect.any(String),
+          transactionIndex: expect.any(Number),
+          logIndex: expect.any(Number),
         },
       ];
 
@@ -597,6 +603,8 @@ describe("identity", () => {
             delegate: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
             blockNumber: 330,
             transactionHash: expect.any(String),
+            transactionIndex: expect.any(Number),
+            logIndex: expect.any(Number),
           },
           {
             name: "DSNPRemoveDelegate",
@@ -605,6 +613,8 @@ describe("identity", () => {
             blockNumber: 331,
             endBlock: 0,
             transactionHash: expect.any(String),
+            transactionIndex: expect.any(Number),
+            logIndex: expect.any(Number),
           },
         ];
 
@@ -626,6 +636,8 @@ describe("identity", () => {
           delegate: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
           blockNumber: 330,
           transactionHash: expect.any(String),
+          transactionIndex: expect.any(Number),
+          logIndex: expect.any(Number),
         },
         {
           name: "DSNPRemoveDelegate",
@@ -634,6 +646,8 @@ describe("identity", () => {
           blockNumber: 331,
           endBlock: 333,
           transactionHash: expect.any(String),
+          transactionIndex: expect.any(Number),
+          logIndex: expect.any(Number),
         },
         {
           name: "DSNPAddDelegate",
@@ -641,6 +655,8 @@ describe("identity", () => {
           delegate: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
           blockNumber: 332,
           transactionHash: expect.any(String),
+          transactionIndex: expect.any(Number),
+          logIndex: expect.any(Number),
         },
       ];
 
@@ -665,6 +681,8 @@ describe("identity", () => {
           delegate: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
           blockNumber: 330,
           transactionHash: expect.any(String),
+          transactionIndex: expect.any(Number),
+          logIndex: expect.any(Number),
         },
         {
           name: "DSNPAddDelegate",
@@ -672,6 +690,8 @@ describe("identity", () => {
           delegate: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
           blockNumber: 332,
           transactionHash: expect.any(String),
+          transactionIndex: expect.any(Number),
+          logIndex: expect.any(Number),
         },
         {
           name: "DSNPRemoveDelegate",
@@ -680,6 +700,8 @@ describe("identity", () => {
           blockNumber: 333,
           endBlock: 400,
           transactionHash: expect.any(String),
+          transactionIndex: expect.any(Number),
+          logIndex: expect.any(Number),
         },
       ];
 

--- a/src/core/contracts/identity.ts
+++ b/src/core/contracts/identity.ts
@@ -492,7 +492,7 @@ const siftDelegateLogs = (logs: ParsedLog[]): DelegateLogData[] => {
         args: { delegate, endBlock },
         name,
       },
-      log: { address, blockNumber, transactionHash },
+      log: { address, blockNumber, transactionHash, transactionIndex, logIndex },
     } = item;
 
     return {
@@ -502,6 +502,8 @@ const siftDelegateLogs = (logs: ParsedLog[]): DelegateLogData[] => {
       transactionHash,
       blockNumber,
       ...(endBlock !== undefined ? { endBlock: endBlock.toNumber() } : {}),
+      logIndex,
+      transactionIndex,
     };
   });
 };

--- a/src/core/contracts/registry.ts
+++ b/src/core/contracts/registry.ts
@@ -173,6 +173,8 @@ export const getDSNPRegistryUpdateEvents = async (
       dsnpUserURI: convertBigNumberToDSNPUserURI(id),
       contractAddr: addr,
       handle,
+      transactionIndex: desc.transactionIndex,
+      logIndex: desc.logIndex,
     };
   });
 };

--- a/src/core/contracts/subscription.test.ts
+++ b/src/core/contracts/subscription.test.ts
@@ -212,6 +212,8 @@ describe("subscription", () => {
           fileUrl: publications1[0].fileUrl,
           fileHash: publications1[0].fileHash,
           announcementType: publications1[0].announcementType,
+          transactionIndex: expect.any(Number),
+          logIndex: expect.any(Number),
         })
       );
       expect(mock.mock.calls[1][0]).toEqual(
@@ -219,6 +221,8 @@ describe("subscription", () => {
           fileUrl: publications2[0].fileUrl,
           fileHash: publications2[0].fileHash,
           announcementType: publications2[0].announcementType,
+          transactionIndex: expect.any(Number),
+          logIndex: expect.any(Number),
         })
       );
       expect(mock.mock.calls[2][0]).toEqual(
@@ -226,6 +230,8 @@ describe("subscription", () => {
           fileUrl: publications3[0].fileUrl,
           fileHash: publications3[0].fileHash,
           announcementType: publications3[0].announcementType,
+          transactionIndex: expect.any(Number),
+          logIndex: expect.any(Number),
         })
       );
 
@@ -281,6 +287,8 @@ describe("subscription", () => {
             dsnpUserURI: expect.any(String),
             contractAddr: identityContractAddress,
             handle: handle,
+            transactionIndex: expect.any(Number),
+            logIndex: expect.any(Number),
           })
         );
         expect(mock.mock.calls[1][0]).toEqual(
@@ -290,6 +298,8 @@ describe("subscription", () => {
             dsnpUserURI: expect.any(String),
             contractAddr: identityContractAddress,
             handle: handleTwo,
+            transactionIndex: expect.any(Number),
+            logIndex: expect.any(Number),
           })
         );
         expect(mock.mock.calls[2][0]).toEqual(
@@ -299,6 +309,8 @@ describe("subscription", () => {
             dsnpUserURI: expect.any(String),
             contractAddr: identityContractAddress,
             handle: handleThree,
+            transactionIndex: expect.any(Number),
+            logIndex: expect.any(Number),
           })
         );
 

--- a/src/core/contracts/subscription.ts
+++ b/src/core/contracts/subscription.ts
@@ -92,6 +92,8 @@ const decodeLogsForBatchPublication = (logs: ethers.providers.Log[]): BatchPubli
         fileUrl: item.fragment.args.fileUrl,
         blockNumber: item.log.blockNumber,
         transactionHash: item.log.transactionHash,
+        transactionIndex: item.log.transactionIndex,
+        logIndex: item.log.logIndex,
       };
     });
 };
@@ -146,6 +148,8 @@ const decodeLogsForRegistryUpdate = (logs: ethers.providers.Log[], contract: Reg
       dsnpUserURI: convertBigNumberToDSNPUserURI(id),
       contractAddr: addr,
       handle,
+      transactionIndex: log.transactionIndex,
+      logIndex: log.logIndex,
     };
   });
 };

--- a/src/core/contracts/utilities.ts
+++ b/src/core/contracts/utilities.ts
@@ -77,6 +77,8 @@ export const createTypedData = (
 export interface LogEventData {
   transactionHash: HexString;
   blockNumber: number;
+  transactionIndex: number;
+  logIndex: number;
 }
 
 /**


### PR DESCRIPTION
Problem
=======
We are missing `transactionIndex` and `logIndex` data from subscriptions and registry updates. [link to Pivotal Tracker #179304614](https://www.pivotaltracker.com/story/show/179304614)

Solution
========
Add the data back. 

Double Checks:
---------------
- [✅ ] Did you update the changelog?
- [✅ ] Any new modules need to be exported?
- [✅ ] Are new methods in the right module?
- [✅ ] Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [✅ ] Do you have good documentation on exported methods?

Change summary:
---------------
* added `transactionIndex` and `logIndex` fields to subscription and registry updated.


Note: This is currently blocking the indexer team. So this PR is against a patch branch that does not include the latest breaking changes. We will deploy a release of this patch branch once it has been approved. 