### PR TITLE
Bugs/inconsistent validation behavior 179304918

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,17 @@
 - Changed isSignatureAuthorizedTo to throw InvalidAnnouncementParameterError when passed an invalid object as announcement
 - Changed AnnouncementWithSignature to take an AnnouncementType instead of a TypedAnnouncement
 - Changed to use bigint for types instead of BigInt
+- Changed content.react() to throw InvalidEmojiStringError when passed an invalid emoji string
+- Changed content.tombstone() to throw InvalidTombstoneAnnouncementTypeError or InvalidTombstoneAnnouncementSignatureError depending on which aspect of the provided target is invalid instead of simply throwing InvalidTombstoneAnnouncementTypeError for both
+- Exported announcement.isValidEmoji() for testing emoji strings
+- Exported announcement.isValidSignature() for testing signature strings
+
+### Added
+- Added announcement.isTombstoneableType() for testing if a given announcement type can be tombstoned
 
 ### Fixed
 - Changed isValidAnnouncement to return false for all announcements missing a createdAt big int
+- Updated content.react() to throw InvalidAnnouncementUriError as specified in its documentation
 
 ## [2.1.1] - 2021-08-17
 ### Changed

--- a/src/content.test.ts
+++ b/src/content.test.ts
@@ -7,6 +7,7 @@ import { createNote, createProfile, InvalidActivityContentError } from "./core/a
 import {
   AnnouncementType,
   SignedBroadcastAnnouncement,
+  InvalidEmojiStringError,
   InvalidTombstoneAnnouncementTypeError,
   InvalidTombstoneAnnouncementSignatureError,
 } from "./core/announcements";
@@ -310,6 +311,22 @@ describe("content", () => {
             "dsnp://0x123456789abcdef/0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
           )
         ).rejects.toThrow(MissingFromIdConfigError);
+      });
+    });
+
+    describe("with an invalid emoji string", () => {
+      it("throws InvalidEmojiStringError", async () => {
+        setConfig({
+          currentFromURI: undefined,
+          signer,
+        });
+
+        await expect(
+          content.react(
+            "not emoji",
+            "dsnp://0x123456789abcdef/0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+          )
+        ).rejects.toThrow(InvalidEmojiStringError);
       });
     });
   });

--- a/src/content.test.ts
+++ b/src/content.test.ts
@@ -8,6 +8,7 @@ import {
   AnnouncementType,
   SignedBroadcastAnnouncement,
   InvalidTombstoneAnnouncementTypeError,
+  InvalidTombstoneAnnouncementSignatureError,
 } from "./core/announcements";
 import { MissingSignerConfigError, MissingStoreConfigError, MissingFromIdConfigError } from "./core/config";
 import { createCloneProxy } from "./core/contracts/identity";
@@ -460,6 +461,22 @@ describe("content", () => {
 
         await expect(content.tombstone(followAnnouncement as unknown as SignedBroadcastAnnouncement)).rejects.toThrow(
           InvalidTombstoneAnnouncementTypeError
+        );
+      });
+    });
+
+    describe("with an invalid target signature", () => {
+      it("throws InvalidTombstoneAnnouncementSignatureError", async () => {
+        setConfig({
+          currentFromURI: "dsnp://0x00000000000003e8",
+          signer,
+          provider,
+        });
+        const broadcastAnnouncement = await content.broadcast(noteObject);
+        broadcastAnnouncement.signature = "0x0";
+
+        await expect(content.tombstone(broadcastAnnouncement)).rejects.toThrow(
+          InvalidTombstoneAnnouncementSignatureError
         );
       });
     });

--- a/src/content.ts
+++ b/src/content.ts
@@ -13,8 +13,10 @@ import {
   createReply,
   createTombstone,
   isTombstoneableType,
+  isValidEmoji,
   isValidSignature,
   sign,
+  InvalidEmojiStringError,
   InvalidTombstoneAnnouncementTypeError,
   InvalidTombstoneAnnouncementSignatureError,
   SignedBroadcastAnnouncement,
@@ -119,6 +121,8 @@ export const reply = async (
  * Thrown if the from id is not configured.
  * @throws {@link InvalidAnnouncementUriError}
  * Thrown if the provided inReplyTo DSNP Message Id is invalid.
+ * @throws {@link InvalidEmojiStringError}
+ * Thrown if the emoji provided is invalid.
  * @param emoji - The emoji with which to react
  * @param inReplyTo - The DSNP Announcement Uri of the announcement to which to react
  * @param opts - Optional. Configuration overrides, such as from address, if any
@@ -129,6 +133,9 @@ export const react = async (
   inReplyTo: DSNPAnnouncementURI,
   opts?: ConfigOpts
 ): Promise<SignedReactionAnnouncement> => {
+  if (!isDSNPAnnouncementURI(inReplyTo)) throw new InvalidAnnouncementUriError(inReplyTo);
+  if (!isValidEmoji(emoji)) throw new InvalidEmojiStringError(emoji);
+
   const currentFromURI = requireGetCurrentFromURI(opts);
 
   const announcement = createReaction(currentFromURI, emoji, inReplyTo);

--- a/src/core/announcements/errors.ts
+++ b/src/core/announcements/errors.ts
@@ -48,3 +48,16 @@ export class InvalidTombstoneAnnouncementSignatureError extends AnnouncementErro
     this.signature = signature;
   }
 }
+
+/**
+ * InvalidEmojiStringError indicates that the emoji string provided is not valid
+ * according to the spec.
+ */
+export class InvalidEmojiStringError extends AnnouncementError {
+  emoji: string;
+
+  constructor(emoji: string) {
+    super(`Invalid Emoji String: ${emoji}`);
+    this.emoji = emoji;
+  }
+}

--- a/src/core/announcements/errors.ts
+++ b/src/core/announcements/errors.ts
@@ -1,5 +1,6 @@
 import { AnnouncementType } from "./factories";
 import { DSNPError } from "../errors";
+import { HexString } from "../../types/Strings";
 
 /**
  * AnnouncementError indicates an error in a DSNP announcement or type.
@@ -32,5 +33,18 @@ export class InvalidTombstoneAnnouncementTypeError extends AnnouncementError {
   constructor(announcementType: AnnouncementType) {
     super(`Invalid Tombstone Target Type: ${announcementType}`);
     this.announcementType = announcementType;
+  }
+}
+
+/**
+ * InvalidTombstoneAnnouncementSignatureError indicates an invalid Announcement
+ * signature included as Tombstone target.
+ */
+export class InvalidTombstoneAnnouncementSignatureError extends AnnouncementError {
+  signature: HexString;
+
+  constructor(signature: HexString) {
+    super(`Invalid Tombstone Target Signature: ${signature}`);
+    this.signature = signature;
   }
 }

--- a/src/core/announcements/validation.test.ts
+++ b/src/core/announcements/validation.test.ts
@@ -1,7 +1,6 @@
 import { setConfig } from "../../config";
 import { register } from "../contracts/registry";
 import { sign } from "./crypto";
-import { AnnouncementError } from "./errors";
 import {
   createBroadcast,
   createReply,
@@ -137,7 +136,7 @@ describe("validation", () => {
         announcement["createdAt"] = undefined as unknown as bigint;
         const signedAnnouncement = await sign(announcement);
 
-        await expect(isValidAnnouncement(signedAnnouncement)).rejects.toThrow(AnnouncementError);
+        expect(await isValidAnnouncement(signedAnnouncement)).toEqual(false);
       });
     });
 

--- a/src/core/announcements/validation.test.ts
+++ b/src/core/announcements/validation.test.ts
@@ -1,7 +1,7 @@
 import { setConfig } from "../../config";
 import { register } from "../contracts/registry";
 import { sign } from "./crypto";
-import { AnnouncementError, InvalidTombstoneAnnouncementTypeError } from "./errors";
+import { AnnouncementError } from "./errors";
 import {
   createBroadcast,
   createReply,
@@ -110,14 +110,14 @@ describe("validation", () => {
         expect(await isValidAnnouncement(signedAnnouncement)).toEqual(true);
       });
 
-      it("throws for a tombstone announcements with an invalid target signature", async () => {
+      it("returns false for a tombstone announcements with an invalid target signature", async () => {
         const announcement = createTombstone(userId, AnnouncementType.Broadcast, "0x0");
         const signedAnnouncement = await sign(announcement);
 
-        await expect(isValidAnnouncement(signedAnnouncement)).rejects.toThrow(AnnouncementError);
+        expect(await isValidAnnouncement(signedAnnouncement)).toEqual(false);
       });
 
-      it("throws for a tombstone announcements with an invalid target type", async () => {
+      it("return false for a tombstone announcements with an invalid target type", async () => {
         const announcement = createTombstone(
           userId,
           AnnouncementType.GraphChange,
@@ -125,7 +125,7 @@ describe("validation", () => {
         );
         const signedAnnouncement = await sign(announcement);
 
-        await expect(isValidAnnouncement(signedAnnouncement)).rejects.toThrow(InvalidTombstoneAnnouncementTypeError);
+        expect(await isValidAnnouncement(signedAnnouncement)).toEqual(false);
       });
 
       it("throws for tombstone announcements without createdAt", async () => {

--- a/src/core/announcements/validation.ts
+++ b/src/core/announcements/validation.ts
@@ -2,7 +2,6 @@ import { ConfigOpts } from "../config";
 import { Permission } from "../contracts/identity";
 import { isSignatureAuthorizedTo } from "../contracts/registry";
 import { SignedAnnouncement } from "./crypto";
-import { AnnouncementError, InvalidTombstoneAnnouncementTypeError } from "./errors";
 import {
   Announcement,
   DSNPGraphChangeType,
@@ -67,13 +66,11 @@ export const isAnnouncementType = (obj: unknown): obj is AnnouncementType => {
  * @returns True if the object is a TombstoneAnnouncement, otherwise false
  */
 export const isTombstoneAnnouncement = (obj: unknown): obj is TombstoneAnnouncement => {
-  if (!isRecord(obj)) throw new AnnouncementError("Announcement is not an object");
-  if (obj["announcementType"] != AnnouncementType.Tombstone)
-    throw new AnnouncementError("Announcement is not tombstone");
-  if (!isDSNPUserId(obj["fromId"])) throw new AnnouncementError("Announcement has invalid fromId");
-  if (!isBigInt(obj["createdAt"])) throw new AnnouncementError("Announcement has invalid createdAt");
-  if (!isAnnouncementType(obj["targetAnnouncementType"]))
-    throw new AnnouncementError("Announcement has invalid targetAnnouncementType");
+  if (!isRecord(obj)) return false;
+  if (obj["announcementType"] != AnnouncementType.Tombstone) return false;
+  if (!isDSNPUserId(obj["fromId"])) return false;
+  if (!isBigInt(obj["createdAt"])) return false;
+  if (!isAnnouncementType(obj["targetAnnouncementType"])) return false;
   if (
     !(
       obj["targetAnnouncementType"] === AnnouncementType.Broadcast ||
@@ -81,9 +78,8 @@ export const isTombstoneAnnouncement = (obj: unknown): obj is TombstoneAnnouncem
       obj["targetAnnouncementType"] === AnnouncementType.Reaction
     )
   )
-    throw new InvalidTombstoneAnnouncementTypeError(obj["targetAnnouncementType"]);
-  if (!isValidSignature(obj["targetSignature"]))
-    throw new AnnouncementError("Announcement has invalid target signature");
+    return false;
+  if (!isValidSignature(obj["targetSignature"])) return false;
 
   return true;
 };

--- a/src/core/announcements/validation.ts
+++ b/src/core/announcements/validation.ts
@@ -31,6 +31,18 @@ const isValidSignature = (obj: unknown): boolean => {
 };
 
 /**
+ * isTombstoneableType() is helper function for checking if a particular
+ * announcement type can be tombstoned.
+ *
+ * @param announcementType - The announcement type to check
+ * @returns True if the announcement type can be tombstoned, otherwise false
+ */
+export const isTombstoneableType = (announcementType: AnnouncementType): boolean =>
+  announcementType === AnnouncementType.Broadcast ||
+  announcementType === AnnouncementType.Reply ||
+  announcementType === AnnouncementType.Reaction;
+
+/**
  * isGraphChangeType() is a type check for DSNPGraphChangeType
  *
  * @param obj - The object to check
@@ -71,14 +83,7 @@ export const isTombstoneAnnouncement = (obj: unknown): obj is TombstoneAnnouncem
   if (!isDSNPUserId(obj["fromId"])) return false;
   if (!isBigInt(obj["createdAt"])) return false;
   if (!isAnnouncementType(obj["targetAnnouncementType"])) return false;
-  if (
-    !(
-      obj["targetAnnouncementType"] === AnnouncementType.Broadcast ||
-      obj["targetAnnouncementType"] === AnnouncementType.Reply ||
-      obj["targetAnnouncementType"] === AnnouncementType.Reaction
-    )
-  )
-    return false;
+  if (!isTombstoneableType(obj["targetAnnouncementType"])) return false;
   if (!isValidSignature(obj["targetSignature"])) return false;
 
   return true;

--- a/src/core/announcements/validation.ts
+++ b/src/core/announcements/validation.ts
@@ -20,18 +20,32 @@ import { isRecord, isString, isNumber, isBigInt } from "../utilities/validation"
 const SIGNATURE_REGEX = /^0x[0-9a-f]{130}$/i;
 const EMOJI_REGEX = /^[\u{2000}-\u{2BFF}\u{E000}-\u{FFFF}\u{1F000}-\u{FFFFF}]+$/u;
 
-const isValidEmoji = (obj: unknown): boolean => {
+/**
+ * isValidEmoji() is a helper function for checking if a given emoji string is
+ * valid according to the spec.
+ *
+ * @param obj - The object to test
+ * @returns True if the given object is a valid emoji, otherwise false
+ */
+export const isValidEmoji = (obj: unknown): boolean => {
   if (!isString(obj)) return false;
   return obj.match(EMOJI_REGEX) !== null;
 };
 
-const isValidSignature = (obj: unknown): boolean => {
+/**
+ * isValidSignature() is a helper function for checking if a given signature is
+ * properly formatted.
+ *
+ * @param obj - The object to test
+ * @returns True if the given object is a valid signature, otherwise false
+ */
+export const isValidSignature = (obj: unknown): boolean => {
   if (!isString(obj)) return false;
   return obj.match(SIGNATURE_REGEX) !== null;
 };
 
 /**
- * isTombstoneableType() is helper function for checking if a particular
+ * isTombstoneableType() is a helper function for checking if a particular
  * announcement type can be tombstoned.
  *
  * @param announcementType - The announcement type to check


### PR DESCRIPTION
Problem
=======
Previously, `announcements.isTombstoneAnnouncement()` threw errors like the activity content validations which is inconsistent with the behavior of the other announcement validations.
[#179304918](https://www.pivotaltracker.com/story/show/179304918)

Solution
========
Updated `announcements.isTombstoneAnnouncement()` to return false and updated content porcelain accordingly so it could still throw specific errors regarding faulty user arguments.

Change summary:
---------------
* Changed content.react() to throw InvalidEmojiStringError when passed an invalid emoji string
* Changed content.tombstone() to throw InvalidTombstoneAnnouncementTypeError or InvalidTombstoneAnnouncementSignatureError depending on which aspect of the provided target is invalid instead of simply throwing InvalidTombstoneAnnouncementTypeError for both
* Exported announcement.isValidEmoji() for testing emoji strings
* Exported announcement.isValidSignature() for testing signature strings
* Added announcement.isTombstoneableType() for testing if a given announcement type can be tombstoned
* Updated content.react() to throw InvalidAnnouncementUriError as specified in its documentation
* Added appropriate tests and documentation for above
