### PR TITLE
Mentions require a a DSNP User URI instead of an Id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixed
 - Changed isValidAnnouncement to return false for all announcements missing a createdAt big int
 - Updated content.react() to throw InvalidAnnouncementUriError as specified in its documentation
+- Updated Mentions so they require a DSNP User URI [per spec](https://spec.dsnp.org/ActivityContent/Associated/Tag#mention) instead of an Id
 
 ### Removed
 - sdk.core.activityContent.serialize: Serialization of activityContent is just JSON.stringify

--- a/src/core/activityContent/factories.ts
+++ b/src/core/activityContent/factories.ts
@@ -1,4 +1,4 @@
-import { DSNPUserId } from "../identifiers";
+import { DSNPUserURI } from "../identifiers";
 import { hash } from "../utilities";
 
 interface ActivityContentBase {
@@ -64,7 +64,7 @@ export interface ActivityContentHashtag {
  */
 export interface ActivityContentMention {
   type: "Mention";
-  id: DSNPUserId;
+  id: DSNPUserURI;
   name?: string;
 }
 
@@ -377,7 +377,7 @@ export const createHashtag = (name: string): ActivityContentHashtag => ({
  * @param options - Any additional fields for the ActivityContentMention
  * @returns An ActivityContentMention object
  */
-export const createMention = (id: DSNPUserId, options?: Partial<ActivityContentMention>): ActivityContentMention => ({
+export const createMention = (id: DSNPUserURI, options?: Partial<ActivityContentMention>): ActivityContentMention => ({
   type: "Mention",
   id,
   ...options,

--- a/src/core/activityContent/validation.test.ts
+++ b/src/core/activityContent/validation.test.ts
@@ -567,8 +567,8 @@ describe("activity content validations", () => {
           content: "Hello world!",
           mediaType: "text/plain",
           tag: [
-            { type: "Mention", id: "0x1001", name: "Spoopy" },
-            { type: "Mention", id: "0x1002", name: "Snoopy" },
+            { type: "Mention", id: "dsnp://0x1001", name: "Spoopy" },
+            { type: "Mention", id: "dsnp://0x1002", name: "Snoopy" },
           ],
         },
         "with an audio attachment": {
@@ -1193,12 +1193,12 @@ describe("activity content validations", () => {
         },
         {
           name: "when a mention tag is invalid",
-          expErr: "ActivityContentMention id is not a valid DSNPUserId",
+          expErr: "ActivityContentMention id is not a valid DSNPUserURI",
           testObject: {
             "@context": "https://www.w3.org/ns/activitystreams",
             type: "Profile",
             content: "Me",
-            tag: [{ type: "Mention", id: 1234, name: "spoopy" }],
+            tag: [{ type: "Mention", id: "badwolf", name: "spoopy" }],
           },
         },
         {

--- a/src/core/activityContent/validation.ts
+++ b/src/core/activityContent/validation.ts
@@ -15,7 +15,7 @@ import {
   ActivityContentMention,
   ActivityContentLocation,
 } from "./factories";
-import { isDSNPUserId } from "../identifiers";
+import { isDSNPUserURI } from "../identifiers";
 import { isRecord, isString, isNumber, isArrayOfType } from "../utilities/validation";
 import { InvalidActivityContentError } from "./errors";
 
@@ -228,8 +228,8 @@ const requireIsActivityContentHashtag = (obj: unknown): obj is ActivityContentHa
 
 const requireIsActivityContentMention = (obj: unknown): obj is ActivityContentMention => {
   if (!isRecord(obj)) throw new InvalidActivityContentError(invalidRecordMessage("ActivityContentMention")); // this check is required for type checking to work
-  if (!isDSNPUserId(obj["id"]))
-    throw new InvalidActivityContentError("ActivityContentMention id is not a valid DSNPUserId");
+  if (!isDSNPUserURI(obj["id"]))
+    throw new InvalidActivityContentError("ActivityContentMention id is not a valid DSNPUserURI");
   if (obj["name"]) requireToString(obj["name"], "ActivityContentMention name");
   return true;
 };


### PR DESCRIPTION
Problem
=======
Mentions were requiring a DSNP User Id instead of a URI as is specified
[link to Pivotal Tracker #179340132](https://www.pivotaltracker.com/story/show/179340132)

Solution
========
Required a DSNP User URI for the validator and the factory

Double Checks:
---------------
- [x] Did you update the changelog?
- [x] Any new modules need to be exported?
- [x] Are new methods in the right module?
- [x] Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [x] Do you have good documentation on exported methods?
