### PR TITLE
convertToDSNPUserURI and convertToDSNPUserId replacing BigNumber methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Added
 - Added announcement.isTombstoneableType() for testing if a given announcement type can be tombstoned
+- sdk.convertToDSNPUserURI for taking most any value and converting it to the DSNP User URI format
+- sdk.convertToDSNPUserId for taking most any value and converting it to the DSNP User Id format
 
 ### Fixed
 - Changed isValidAnnouncement to return false for all announcements missing a createdAt big int
@@ -25,6 +27,10 @@
 ### Removed
 - sdk.core.activityContent.serialize: Serialization of activityContent is just JSON.stringify
 - sdk.core.utilities.sortObject: Unused method
+- sdk.convertBigNumberToDSNPUserId: Not supporting BigNumber anymore
+- sdk.convertDSNPUserIdOrURIToBigNumber: Not supporting BigNumber anymore
+- sdk.convertBigNumberToDSNPUserURI: Not supporting BigNumber anymore
+- Removed sdk.convertDSNPUserURIToDSNPUserId: Just use convertToDSNPUserId and convertToDSNPUserURI 
 
 ## [2.1.2] - 2021-08-20
 ### fixed

--- a/src/core/announcements/factories.ts
+++ b/src/core/announcements/factories.ts
@@ -1,4 +1,4 @@
-import { convertDSNPUserURIToDSNPUserId, DSNPAnnouncementURI, DSNPUserId, DSNPUserURI } from "../identifiers";
+import { convertToDSNPUserId, DSNPAnnouncementURI, DSNPUserId, DSNPUserURI } from "../identifiers";
 import { HexString } from "../../types/Strings";
 import { createdAtOrNow } from "../utilities";
 
@@ -90,7 +90,7 @@ export const createTombstone = (
   targetAnnouncementType: targetType,
   targetSignature,
   createdAt: createdAtOrNow(createdAt),
-  fromId: convertDSNPUserURIToDSNPUserId(fromURI),
+  fromId: convertToDSNPUserId(fromURI),
 });
 
 /**
@@ -117,7 +117,7 @@ export const createBroadcast = (
   announcementType: AnnouncementType.Broadcast,
   contentHash: hash,
   createdAt: createdAtOrNow(createdAt),
-  fromId: convertDSNPUserURIToDSNPUserId(fromURI),
+  fromId: convertToDSNPUserId(fromURI),
   url,
 });
 
@@ -147,7 +147,7 @@ export const createReply = (
   announcementType: AnnouncementType.Reply,
   contentHash: hash,
   createdAt: createdAtOrNow(createdAt),
-  fromId: convertDSNPUserURIToDSNPUserId(fromURI),
+  fromId: convertToDSNPUserId(fromURI),
   inReplyTo,
   url,
 });
@@ -176,7 +176,7 @@ export const createReaction = (
   announcementType: AnnouncementType.Reaction,
   createdAt: createdAtOrNow(createdAt),
   emoji,
-  fromId: convertDSNPUserURIToDSNPUserId(fromURI),
+  fromId: convertToDSNPUserId(fromURI),
   inReplyTo,
 });
 
@@ -207,11 +207,11 @@ export const createFollowGraphChange = (
   followeeURI: DSNPUserURI,
   createdAt?: bigint
 ): GraphChangeAnnouncement => ({
-  fromId: convertDSNPUserURIToDSNPUserId(fromURI),
   announcementType: AnnouncementType.GraphChange,
   changeType: DSNPGraphChangeType.Follow,
   createdAt: createdAtOrNow(createdAt),
-  objectId: convertDSNPUserURIToDSNPUserId(followeeURI),
+  fromId: convertToDSNPUserId(fromURI),
+  objectId: convertToDSNPUserId(followeeURI),
 });
 
 /**
@@ -228,11 +228,11 @@ export const createUnfollowGraphChange = (
   followeeURI: DSNPUserURI,
   createdAt?: bigint
 ): GraphChangeAnnouncement => ({
-  fromId: convertDSNPUserURIToDSNPUserId(fromURI),
   announcementType: AnnouncementType.GraphChange,
   changeType: DSNPGraphChangeType.Unfollow,
   createdAt: createdAtOrNow(createdAt),
-  objectId: convertDSNPUserURIToDSNPUserId(followeeURI),
+  fromId: convertToDSNPUserId(fromURI),
+  objectId: convertToDSNPUserId(followeeURI),
 });
 
 /**
@@ -258,6 +258,6 @@ export const createProfile = (
   announcementType: AnnouncementType.Profile,
   contentHash: hash,
   createdAt: createdAtOrNow(createdAt),
-  fromId: convertDSNPUserURIToDSNPUserId(fromURI),
+  fromId: convertToDSNPUserId(fromURI),
   url,
 });

--- a/src/core/contracts/registry.test.ts
+++ b/src/core/contracts/registry.test.ts
@@ -27,7 +27,7 @@ import {
   RegistrationWithSigner,
 } from "../../test/testAccounts";
 import { generateHexString } from "@dsnp/test-generators";
-import { convertDSNPUserURIToDSNPUserId, DSNPUserURI } from "../identifiers";
+import { DSNPUserURI } from "../identifiers";
 import { EthereumAddress } from "../../types/Strings";
 import { mineBlocks } from "../../test/utilities";
 
@@ -194,15 +194,17 @@ describe("registry", () => {
       const identityContractAddress = identityContract.address;
       await register(identityContractAddress, handle);
 
+      const { dsnpUserURI } = (await resolveRegistration(handle)) || {};
+
       const regs = await getDSNPRegistryUpdateEvents({
-        contractAddr: identityContractAddress,
+        dsnpUserURI,
       });
 
       const expected = expect.objectContaining({
         transactionHash: expect.any(String),
         blockNumber: expect.any(Number),
         contractAddr: identityContractAddress,
-        dsnpUserURI: "dsnp://0x" + Number(1000).toString(16),
+        dsnpUserURI,
         handle: handle,
       });
 
@@ -411,7 +413,7 @@ describe("registry", () => {
       const tx = await register(contractAddr, "Animaniacs");
       dsnpUserURI = await getURIFromRegisterTransaction(tx);
       msg = createBroadcast(
-        convertDSNPUserURIToDSNPUserId(dsnpUserURI),
+        dsnpUserURI,
         "https://fakeurl.org",
         "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
       );

--- a/src/core/contracts/subscription.ts
+++ b/src/core/contracts/subscription.ts
@@ -6,8 +6,8 @@ import { Publisher__factory } from "../../types/typechain";
 import { LogDescription } from "@ethersproject/abi";
 import { LogEventData, subscribeToEvent, UnsubscribeFunction } from "./utilities";
 import { RegistryUpdateLogData, getContract } from "./registry";
-import { convertBigNumberToDSNPUserURI } from "../identifiers";
 import { Registry } from "../../types/typechain";
+import { convertToDSNPUserURI } from "../identifiers";
 
 const PUBLISHER_DECODER = new ethers.utils.Interface(Publisher__factory.abi);
 
@@ -145,7 +145,7 @@ const decodeLogsForRegistryUpdate = (logs: ethers.providers.Log[], contract: Reg
     return {
       blockNumber,
       transactionHash,
-      dsnpUserURI: convertBigNumberToDSNPUserURI(id),
+      dsnpUserURI: convertToDSNPUserURI(id),
       contractAddr: addr,
       handle,
       transactionIndex: log.transactionIndex,

--- a/src/core/identifiers/identifiers.test.ts
+++ b/src/core/identifiers/identifiers.test.ts
@@ -1,9 +1,7 @@
 import {
   buildDSNPAnnouncementURI,
-  convertBigNumberToDSNPUserId,
-  convertBigNumberToDSNPUserURI,
-  convertDSNPUserIdOrURIToBigNumber,
-  convertDSNPUserURIToDSNPUserId,
+  convertToDSNPUserId,
+  convertToDSNPUserURI,
   isDSNPAnnouncementURI,
   isDSNPUserURI,
   parseDSNPAnnouncementURI,
@@ -12,16 +10,12 @@ import { BigNumber } from "ethers";
 
 describe("identifiers", () => {
   describe("isDSNPUserURI", () => {
-    const validDSNPUserURIs = [
-      "dsnp://0xa123456789abcdef", // Lowercase
-    ];
+    const validDSNPUserURIs = ["dsnp://0xa123456789abcdef"];
 
     const invalidDSNPUserURIs = [
-      "dsnp://0xa123456789ABCDEF", // Uppercase
-      "dsnp://0x0000456789abcdef", // Leading Zeros
-      "dsnp://0123456789abcdef", // No 0x user
-      "dsnp://0xbadwolf", // Bad user URI
-      "dsnp://0xa123456789abcdefa", // URI too long
+      "dsnp://123", // hex
+      "dsnp://badwolf", // Bad user URI
+      "dsnp://184467440737095516150", // URI too long
     ];
 
     for (const id of validDSNPUserURIs) {
@@ -97,43 +91,39 @@ describe("identifiers", () => {
     });
   });
 
-  describe("convertBigNumberToDSNPUserId", () => {
-    it("is prefixed with 0x", () => {
-      expect(convertBigNumberToDSNPUserId(BigNumber.from(4660))).toEqual("0x1234");
+  describe("convertToDSNPUserURI", () => {
+    it("big number", () => {
+      expect(convertToDSNPUserURI(BigNumber.from(4660))).toEqual("dsnp://0x1234");
+    });
+
+    it("number", () => {
+      expect(convertToDSNPUserURI(4660)).toEqual("dsnp://0x1234");
+    });
+
+    it("hex string", () => {
+      expect(convertToDSNPUserURI("0x0001234")).toEqual("dsnp://0x1234");
+    });
+
+    it("dsnp user uri", () => {
+      expect(convertToDSNPUserURI("dsnp://0x1234")).toEqual("dsnp://0x1234");
     });
   });
 
-  describe("convertDSNPUserIdOrURIToBigNumber", () => {
-    it("can convert a DSNP URI", () => {
-      const result = convertDSNPUserIdOrURIToBigNumber("dsnp://0x1234");
-      expect(BigNumber.isBigNumber(result)).toBeTruthy();
-      expect(result.toNumber()).toEqual(0x1234);
+  describe("convertToDSNPUserId", () => {
+    it("big number", () => {
+      expect(convertToDSNPUserId(BigNumber.from(4660))).toEqual("0x1234");
     });
 
-    it("can convert a DSNP Id", () => {
-      const result = convertDSNPUserIdOrURIToBigNumber("0x01234");
-      expect(BigNumber.isBigNumber(result)).toBeTruthy();
-      expect(result.toNumber()).toEqual(0x1234);
+    it("number", () => {
+      expect(convertToDSNPUserId(4660)).toEqual("0x1234");
     });
 
-    it("can convert a DSNP Id even without the prefix", () => {
-      const result = convertDSNPUserIdOrURIToBigNumber("1234");
-      expect(BigNumber.isBigNumber(result)).toBeTruthy();
-      expect(result.toNumber()).toEqual(0x1234);
+    it("hex string", () => {
+      expect(convertToDSNPUserId("0x0001234")).toEqual("0x1234");
     });
-  });
 
-  describe("convertBigNumberToDSNPUserURI", () => {
-    it("has no zero padding", () => {
-      const result = convertBigNumberToDSNPUserURI(BigNumber.from("0x000000123"));
-      expect(result).toEqual("dsnp://0x123");
-    });
-  });
-
-  describe("convertDSNPUserURIToDSNPUserId", () => {
-    it("returns no leading zeros", () => {
-      const result = convertDSNPUserURIToDSNPUserId("dsnp://0x123");
-      expect(result).toEqual("0x123");
+    it("dsnp user uri", () => {
+      expect(convertToDSNPUserId("dsnp://0x1234")).toEqual("0x1234");
     });
   });
 });

--- a/src/core/identifiers/identifiers.ts
+++ b/src/core/identifiers/identifiers.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from "ethers";
 import { isString } from "../utilities/validation";
 import { HexString } from "../../types/Strings";
 import { serializeToHex } from "../announcements";
@@ -58,44 +57,25 @@ export const isDSNPUserURI = (uri: unknown): uri is DSNPUserURI => {
 };
 
 /**
- * convertBigNumberToDSNPUserId() converts ethers' ridiculous BigNumber
- * implementation hex output to a proper DSNP user id.
+ * convertToDSNPUserId() converts just about any valid DSNP User URI, BigNumber,
+ * hex string, etc... to a proper DSNP User Id.
  *
- * @param num - The number to convert
- * @returns The same number as a properly formatted DSNPUserId
+ * @param value - The unknown value to parse to a DSNP User Id
+ * @returns The same value as a properly formatted DSNPUserId
  */
-export const convertBigNumberToDSNPUserId = (num: BigNumber): DSNPUserId => serializeToHex(num);
-
-/**
- * convertDSNPUserIdOrURIToBigNumber() convert a DSNP user id or URI to an
- * ethers BigNumber.
- *
- * @param userIdOrUri - The DSNP user id or URI to convert
- * @returns A big number representation of the same id
- */
-export const convertDSNPUserIdOrURIToBigNumber = (userIdOrUri: DSNPUserId | DSNPUserURI): BigNumber => {
-  return BigNumber.from(serializeToHex(userIdOrUri));
+export const convertToDSNPUserId = (value: unknown): DSNPUserId => {
+  return serializeToHex(value);
 };
 
 /**
- * convertDSNPUserURIToDSNPUserId() converts a DSNP user URI to a DSNP user id.
+ * convertToDSNPUserURI() converts just about any valid DSNP User id, BigNumber,
+ * hex string, etc... to a proper DSNP User URI.
  *
- * @param userURI - The DSNPUserURI to convert
- * @returns The DSNPUserId of the user
+ * @param value - The string
+ * @returns The same value as a properly formatted DSNPUserURI
  */
-export const convertDSNPUserURIToDSNPUserId = (userURI: DSNPUserURI): DSNPUserId => {
-  return serializeToHex(userURI);
-};
-
-/**
- * convertBigNumberToDSNPUserURI() converts ethers' ridiculous BigNumber
- * implementation hex output to a proper DSNP user URI.
- *
- * @param num - The number to convert
- * @returns The same number as a properly formatted DSNPUserURI
- */
-export const convertBigNumberToDSNPUserURI = (num: BigNumber): DSNPUserURI => {
-  return `dsnp://${serializeToHex(num)}`;
+export const convertToDSNPUserURI = (value: unknown): DSNPUserURI => {
+  return `dsnp://${convertToDSNPUserId(value)}`;
 };
 
 /**
@@ -110,7 +90,7 @@ export const buildDSNPAnnouncementURI = (
   userIdOrUri: DSNPUserId | DSNPUserURI,
   contentHash: HexString
 ): DSNPAnnouncementURI => {
-  return `dsnp://${serializeToHex(userIdOrUri)}/${serializeToHex(contentHash)}`;
+  return `dsnp://${convertToDSNPUserId(userIdOrUri)}/${serializeToHex(contentHash)}`;
 };
 
 /**

--- a/src/handles.test.ts
+++ b/src/handles.test.ts
@@ -7,7 +7,7 @@ import { setupConfig } from "./test/sdkTestConfig";
 import { revertHardhat, snapshotHardhat, setupSnapshot } from "./test/hardhatRPC";
 import { ethers } from "ethers";
 import { EthAddressRegex } from "./test/matchers";
-import { convertDSNPUserIdOrURIToBigNumber } from "./core/identifiers";
+import { convertToDSNPUserId } from "./core/identifiers";
 
 const createIdentityContract = async () => {
   const receipt = await (await createCloneProxy()).wait();
@@ -109,9 +109,9 @@ describe("handles", () => {
 
     it("returns a DSNP User URI", async () => {
       const dsnpUserURI = await createRegistration(fakeAddress, handle);
-      const id = convertDSNPUserIdOrURIToBigNumber(dsnpUserURI);
+      const id = convertToDSNPUserId(dsnpUserURI);
 
-      expect(id.toNumber()).toBeGreaterThan(999);
+      expect(parseInt(id)).toBeGreaterThan(999);
       expect(dsnpUserURI.substr(0, 9)).toEqual("dsnp://0x");
     });
   });

--- a/src/handles.ts
+++ b/src/handles.ts
@@ -2,7 +2,7 @@ import * as config from "./core/config";
 import { Registration, Handle, getDSNPRegistryUpdateEvents, resolveRegistration } from "./core/contracts/registry";
 import { createAndRegisterBeaconProxy } from "./core/contracts/identity";
 import { findEvent } from "./core/contracts/contract";
-import { convertBigNumberToDSNPUserURI, DSNPUserURI } from "./core/identifiers";
+import { convertToDSNPUserURI, DSNPUserURI } from "./core/identifiers";
 import { HexString } from "./types/Strings";
 
 /**
@@ -29,7 +29,7 @@ export const createRegistration = async (
   const receipt = await txn.wait(1);
 
   const registerEvent = findEvent("DSNPRegistryUpdate", receipt.logs);
-  return convertBigNumberToDSNPUserURI(registerEvent.args[0]);
+  return convertToDSNPUserURI(registerEvent.args[0]);
 };
 
 /**

--- a/src/network.test.ts
+++ b/src/network.test.ts
@@ -7,12 +7,7 @@ import { DSNPGraphChangeType, AnnouncementType } from "./core/announcements";
 import { Identity__factory } from "./types/typechain";
 import { setupConfig } from "./test/sdkTestConfig";
 import { revertHardhat, snapshotHardhat, setupSnapshot } from "./test/hardhatRPC";
-import {
-  convertBigNumberToDSNPUserId,
-  convertBigNumberToDSNPUserURI,
-  DSNPUserId,
-  DSNPUserURI,
-} from "./core/identifiers";
+import { convertToDSNPUserId, convertToDSNPUserURI, DSNPUserId, DSNPUserURI } from "./core/identifiers";
 
 describe("network", () => {
   let registerId: DSNPUserId;
@@ -32,8 +27,8 @@ describe("network", () => {
     const receipt = await txn.wait(1);
 
     const registerEvent = findEvent("DSNPRegistryUpdate", receipt.logs);
-    registerURI = convertBigNumberToDSNPUserURI(registerEvent.args[0]);
-    registerId = convertBigNumberToDSNPUserId(registerEvent.args[0]);
+    registerURI = convertToDSNPUserURI(registerEvent.args[0]);
+    registerId = convertToDSNPUserId(registerEvent.args[0]);
   });
 
   afterAll(async () => {

--- a/src/test/testAccounts.ts
+++ b/src/test/testAccounts.ts
@@ -2,7 +2,7 @@ import { ContractTransaction, ethers } from "ethers";
 import { requireGetProvider } from "../core/config";
 import { register, Registration } from "../core/contracts/registry";
 import { Identity__factory, Registry__factory } from "../types/typechain";
-import { convertBigNumberToDSNPUserURI, DSNPUserURI } from "../core/identifiers";
+import { convertToDSNPUserURI, DSNPUserURI } from "../core/identifiers";
 
 export interface RegistrationWithSigner extends Registration {
   signer: ethers.Signer;
@@ -136,7 +136,7 @@ export const getURIFromRegisterTransaction = async (transaction: ContractTransac
   const receipt = await transaction.wait(1);
   const reg = Registry__factory.createInterface();
   const event = reg.parseLog(receipt.logs[0]);
-  return convertBigNumberToDSNPUserURI(event.args[0]);
+  return convertToDSNPUserURI(event.args[0]);
 };
 
 /**


### PR DESCRIPTION
Problem
=======
We don't want to have ethers BigNumber used outside of the sdk, so better methods to cast these to the correct formats.

Also prep for switching DSNP User Id to bigint

Solution
========
Replaced convert in and out of BigNumber methods with just convertToDSNPUserURI and convertToDSNPUserId

Double Checks:
---------------
- [x] Did you update the changelog?
- [x] Any new modules need to be exported?
- [x] Are new methods in the right module?
- [x] Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [x] Do you have good documentation on exported methods?

Change summary:
---------------
- Removed convertDSNPUserURIToDSNPUserId
- Removed convertBigNumberToDSNPUserId
- Removed convertDSNPUserIdOrURIToBigNumber
- Removed convertBigNumberToDSNPUserURI
- Added convertToDSNPUserURI
- Added convertToDSNPUserId
