### PR TITLE
Exclude test files in packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,12 @@
     "watch": "run-s build && run-p \"build:cjs -- -w\" \"build:esm -- -w\" \"build:types -- -w\" \"test -- --watch\""
   },
   "files": [
-    "dist/**/*",
+    "dist/cjs/**/!(*.test).js",
+    "dist/esm/**/!(*.test).js",
+    "dist/types/**/!(*.test).d.ts",
     "docs/**/*",
-    "core/**/*",
-    "generators/**/*",
+    "core/**/!(*.test).{js,ts,d.ts}",
+    "generators/**/!(*.test).{js,ts,d.ts}",
     "CONTRIBUTING.md",
     "*.js",
     "*.d.ts"


### PR DESCRIPTION
Problem
=======
Test files were included in the package, but should not be.

Solution
========
Update the include list under package.json -> files

Steps to Verify:
----------------
1. npm run clean && npm run build
1. npm run pack (on this commit)
1. npm run pack (on previous comment)
1. See that nothing has changed except we removed test files

<img width="1643" alt="image" src="https://user-images.githubusercontent.com/1252199/130832981-92d37252-adb2-4d1c-bcea-da8b17b4a31e.png">

