### PR TITLE
batch.readFile will now await doReadRow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- sdk.core.batch.readFile will now await `doReadRow` 
+
 ## [3.0.0] - 2021-08-25
 ### Changed
 - BREAKING: Changed batch.readFile() to pass parsed announcements instead of parquet records to callback

--- a/src/core/batch/batch.ts
+++ b/src/core/batch/batch.ts
@@ -10,7 +10,7 @@ import { AsyncOrSyncIterable, getHashGenerator } from "../utilities";
 import { hexToUint8Array, uint8ArrayToHex } from "./buffers";
 
 type ReadRowFunction<T extends SignedAnnouncement> = {
-  (row: T): void;
+  (row: T): void | Promise<void>;
 };
 
 interface SplitBlockBloomFilter {
@@ -195,7 +195,7 @@ export const readFile = async <T extends SignedAnnouncement>(
   let record: ParquetRecord | null = null;
   while ((record = await cursor.next())) {
     const announcement = parseAnnouncement<T>(record);
-    doReadRow(announcement);
+    await doReadRow(announcement);
   }
 
   return reader.close();


### PR DESCRIPTION
Problem
=======
Wanted to be able to perform async actions inside of doReadRow
[#179386996](https://www.pivotaltracker.com/story/show/179386996)

Solution
========
Expanded the signature to allow for void or Promise<void> and await'd the callback

Double Checks:
---------------
- [x] Did you update the changelog?
- [x] Any new modules need to be exported?
- [x] Are new methods in the right module?
- [x] Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [x] Do you have good documentation on exported methods?