### PR TITLE
v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+## [3.0.1] - 2021-08-27
 ### Added
 - sdk.core.batch.readFile will now await `doReadRow` 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dsnp/sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dsnp/sdk",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dsnp/contracts": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsnp/sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "SDK Library for the DSNP",
   "type": "commonjs",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
## [3.0.1] - 2021-08-27
### Added
- sdk.core.batch.readFile will now await `doReadRow` 