### PR TITLE
Document contracts.utilities.subscribeToEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
 ## Unreleased
+### Added
+- Code documentation and additional test on subscribeToEvent
+
 ### Fixed
 - subscribeToEvent zero value for fromBlock param fetches logs starting at zero
 - batch.openURL to coerce URL to string before passing to ParquetJS
+- Fixed flaky tests around registry
 
 ## [3.0.1] - 2021-08-27
 ### Added

--- a/src/core/contracts/registry.test.ts
+++ b/src/core/contracts/registry.test.ts
@@ -29,7 +29,6 @@ import {
 import { generateHexString } from "@dsnp/test-generators";
 import { DSNPUserURI } from "../identifiers";
 import { EthereumAddress } from "../../types/Strings";
-import { mineBlocks } from "../../test/utilities";
 
 describe("registry", () => {
   let signer: Signer;
@@ -39,6 +38,10 @@ describe("registry", () => {
 
   beforeAll(() => {
     ({ signer, provider } = setupConfig());
+  });
+
+  beforeEach(async () => {
+    await provider.getBlockNumber();
   });
 
   describe("#resolveRegistration", () => {
@@ -276,20 +279,25 @@ describe("registry", () => {
       const handleTwo = "DonkeyButtons2";
       const handleThree = "DonkeyButtons3";
 
+      // Excluded
       const identityContractAddress = identityContract.address;
-      await register(identityContractAddress, handle);
+      const transaction1 = await register(identityContractAddress, handle);
+      const receipt1 = await transaction1.wait(1);
+      const currentBlockNumber = receipt1.blockNumber;
 
-      await mineBlocks(10, provider);
+      // Included
+      const transaction2 = await changeHandle(handle, handleTwo);
+      const receipt2 = await transaction2.wait(1);
+      expect(receipt2.blockNumber).toBeGreaterThanOrEqual(currentBlockNumber + 1);
 
-      const currentBlockNumber = await provider.getBlockNumber();
-      await changeHandle(handle, handleTwo);
-
-      await mineBlocks(10, provider);
-      await changeHandle(handleTwo, handleThree);
+      // Included
+      const transaction3 = await changeHandle(handleTwo, handleThree);
+      const receipt3 = await transaction3.wait(1);
+      expect(receipt3.blockNumber).toBeGreaterThanOrEqual(currentBlockNumber + 2);
 
       const result = await getDSNPRegistryUpdateEvents({
-        fromBlock: currentBlockNumber,
-        endBlock: currentBlockNumber + 10,
+        fromBlock: currentBlockNumber + 1,
+        endBlock: currentBlockNumber + 2,
       });
 
       const expected = expect.arrayContaining([
@@ -304,7 +312,7 @@ describe("registry", () => {
         }),
       ]);
 
-      expect(result.length).toEqual(1);
+      expect(result.length).toEqual(2);
       expect(result).toEqual(expected);
       expect(result).toEqual(expectedTwo);
     });
@@ -319,14 +327,12 @@ describe("registry", () => {
       const identityContractAddress = identityContract.address;
       await register(identityContractAddress, handle);
 
-      await mineBlocks(10, provider);
-
       const currentBlockNumber = await provider.getBlockNumber();
       await changeHandle(handle, handleTwo);
-      await changeHandle(handleTwo, handleThree);
-      await mineBlocks(10, provider);
+      const transaction = await changeHandle(handleTwo, handleThree);
+      const receipt = await transaction.wait(1);
 
-      expect(await provider.getBlockNumber()).toBeGreaterThan(currentBlockNumber + 10);
+      expect(receipt.blockNumber).toBeGreaterThan(currentBlockNumber);
 
       const result = await getDSNPRegistryUpdateEvents({
         fromBlock: currentBlockNumber,
@@ -361,14 +367,14 @@ describe("registry", () => {
       const identityContractAddress = identityContract.address;
       await register(identityContractAddress, handle);
 
-      await mineBlocks(10, provider);
-
       await changeHandle(handle, handleTwo);
 
       const currentBlockNumber = await provider.getBlockNumber();
 
-      await mineBlocks(10, provider);
-      await changeHandle(handleTwo, handleThree);
+      const transaction = await changeHandle(handleTwo, handleThree);
+      const receipt = await transaction.wait(1);
+      expect(currentBlockNumber).toBeLessThanOrEqual(await provider.getBlockNumber());
+      expect(receipt.blockNumber).toBeGreaterThan(currentBlockNumber);
 
       const result = await getDSNPRegistryUpdateEvents({
         endBlock: currentBlockNumber,

--- a/src/core/contracts/registry.test.ts
+++ b/src/core/contracts/registry.test.ts
@@ -323,10 +323,10 @@ describe("registry", () => {
 
       const currentBlockNumber = await provider.getBlockNumber();
       await changeHandle(handle, handleTwo);
-
-      await mineBlocks(10, provider);
       await changeHandle(handleTwo, handleThree);
       await mineBlocks(10, provider);
+
+      expect(await provider.getBlockNumber()).toBeGreaterThan(currentBlockNumber + 10);
 
       const result = await getDSNPRegistryUpdateEvents({
         fromBlock: currentBlockNumber,

--- a/src/core/contracts/utilities.test.ts
+++ b/src/core/contracts/utilities.test.ts
@@ -16,7 +16,7 @@ describe("#subscribeToEvent", () => {
       const log3 = { blockNumber: 53, logIndex: 1, transactionHash: "0xc" } as ethers.providers.Log;
       const log4 = { blockNumber: 55, logIndex: 1, transactionHash: "0xd" } as ethers.providers.Log;
 
-      let mockBlockNumber = 52;
+      const mockBlockNumber = 52;
       let providerOnCallback: ProviderOnCb = jest.fn();
 
       const eventFilter: ethers.EventFilter = { topics: [] };

--- a/src/core/contracts/utilities.test.ts
+++ b/src/core/contracts/utilities.test.ts
@@ -1,14 +1,56 @@
 import { ethers } from "ethers";
 
 import { subscribeToEvent } from "./utilities";
+import { checkNumberOfFunctionCalls } from "../../test/utilities";
+
+type ProviderOnCb = (log: ethers.providers.Log) => void;
 
 describe("#subscribeToEvent", () => {
   afterAll(jest.restoreAllMocks);
+
+  describe("edge condition", () => {
+    it("doesn't miss or duplicate any when there are events in the currentBlockNumber", async () => {
+      const log1 = { blockNumber: 51, logIndex: 1, transactionHash: "0xa" } as ethers.providers.Log;
+      const log2 = { blockNumber: 52, logIndex: 1, transactionHash: "0xb" } as ethers.providers.Log;
+      const log22 = { blockNumber: 52, logIndex: 2, transactionHash: "0xb" } as ethers.providers.Log;
+      const log3 = { blockNumber: 53, logIndex: 1, transactionHash: "0xc" } as ethers.providers.Log;
+      const log4 = { blockNumber: 55, logIndex: 1, transactionHash: "0xd" } as ethers.providers.Log;
+
+      let mockBlockNumber = 52;
+      let providerOnCallback: ProviderOnCb = jest.fn();
+
+      const eventFilter: ethers.EventFilter = { topics: [] };
+      const providerOn = jest.fn().mockImplementation((_filter: ethers.EventFilter, callback: ProviderOnCb) => {
+        providerOnCallback = callback;
+        // Overlap of log2 and log22
+        [log2, log22, log3].forEach(callback);
+      });
+
+      const mockProvider = {
+        on: providerOn,
+        getBlockNumber: jest.fn().mockImplementation(() => {
+          return mockBlockNumber;
+        }),
+        // Overlap of log2 and log22
+        getLogs: jest.fn().mockResolvedValue([log1, log2, log22]),
+        off: jest.fn(),
+      } as unknown as ethers.providers.Provider;
+
+      const doReceiveEventMock = jest.fn();
+
+      await subscribeToEvent(mockProvider, eventFilter, doReceiveEventMock, 50);
+      // Now call after we have "caught up" to make sure it switches to streaming
+      providerOnCallback(log4);
+      await checkNumberOfFunctionCalls(doReceiveEventMock, 10, 5);
+      expect(doReceiveEventMock).toHaveBeenCalledTimes(5);
+    });
+  });
 
   describe("when starting block number (fromBlock) is not provided", () => {
     const mockProvider = {
       on: jest.fn(),
       off: jest.fn(),
+      getLogs: jest.fn().mockResolvedValue([]),
       getBlockNumber: jest.fn(),
     } as unknown as ethers.providers.Provider;
     const eventFilter: ethers.EventFilter = { topics: [] };
@@ -43,12 +85,10 @@ describe("#subscribeToEvent", () => {
       const log1 = { blockNumber: 0 } as ethers.providers.Log;
       const log2 = { blockNumber: 75 } as ethers.providers.Log;
       const eventFilter: ethers.EventFilter = { topics: [] };
-      const providerOn = jest
-        .fn()
-        .mockImplementation((_filter: ethers.EventFilter, callback: (log: ethers.providers.Log) => void) => {
-          const currentLog = { blockNumber: 100 } as ethers.providers.Log;
-          callback(currentLog);
-        });
+      const providerOn = jest.fn().mockImplementation((_filter: ethers.EventFilter, callback: ProviderOnCb) => {
+        const currentLog = { blockNumber: 100 } as ethers.providers.Log;
+        callback(currentLog);
+      });
 
       const mockProvider = {
         on: providerOn,
@@ -96,12 +136,10 @@ describe("#subscribeToEvent", () => {
       describe("and the start block number (fromBlock 200) is greater than the current block number (99)", () => {
         const fromBlock = 200;
         const eventFilter: ethers.EventFilter = { topics: [] };
-        const providerOn = jest
-          .fn()
-          .mockImplementation((_filter: ethers.EventFilter, callback: (log: ethers.providers.Log) => void) => {
-            const currentLog = { blockNumber: 99 } as ethers.providers.Log;
-            callback(currentLog);
-          });
+        const providerOn = jest.fn().mockImplementation((_filter: ethers.EventFilter, callback: ProviderOnCb) => {
+          const currentLog = { blockNumber: 99 } as ethers.providers.Log;
+          callback(currentLog);
+        });
 
         const mockProvider = {
           on: providerOn,


### PR DESCRIPTION
Problem
=======
We thought there was a way to be a race condition with starting to get new posts, and getting older posts in subscribeToEvent, but turns out there is not.
[#179437626](https://www.pivotaltracker.com/story/show/179437626)

Solution
========
- Added more documentation to be clear about how ethers works to prevent any overlap.
- Added an extra test around subscribeToEvent
- Updated registry tests to remove test flakiness

with @acruikshank 

Double Checks:
---------------
- [x] Did you update the changelog?
- [x] Any new modules need to be exported?
- [x] Are new methods in the right module?
- [x] Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [x] Do you have good documentation on exported methods?

Summary:
---------------
- Code documentation and additional test on subscribeToEvent
- Fixed flaky tests around registry
