### PR TITLE
fix(subscribeToEvent): allow fromBlock zero value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Fixed
+- subscribeToEvent zero value for fromBlock param fetches logs starting at zero
 
 ## [3.0.1] - 2021-08-27
 ### Added

--- a/src/core/contracts/utilities.test.ts
+++ b/src/core/contracts/utilities.test.ts
@@ -38,9 +38,9 @@ describe("#subscribeToEvent", () => {
   });
 
   describe("when a starting block number (fromBlock) is provided", () => {
-    describe("and the starting block number (fromBlock: 50) is less current block number (99)", () => {
-      const fromBlock = 50;
-      const log1 = { blockNumber: 50 } as ethers.providers.Log;
+    describe("and the starting block number (fromBlock: 0) is less current block number (99)", () => {
+      const fromBlock = 0;
+      const log1 = { blockNumber: 0 } as ethers.providers.Log;
       const log2 = { blockNumber: 75 } as ethers.providers.Log;
       const eventFilter: ethers.EventFilter = { topics: [] };
       const providerOn = jest

--- a/src/core/contracts/utilities.ts
+++ b/src/core/contracts/utilities.ts
@@ -102,7 +102,7 @@ export const subscribeToEvent = async (
   doReceiveEvent: (log: ethers.providers.Log) => void,
   fromBlock?: number
 ): Promise<UnsubscribeFunction> => {
-  if (!fromBlock) {
+  if (fromBlock === undefined) {
     provider.on(filter, doReceiveEvent);
 
     return () => provider.off(filter);


### PR DESCRIPTION
Ensure that when setting fromBlock to zero
that is does not get interpreted as falsy
and that it fetches event data from zero block.

