### PR TITLE
v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+
+## [3.0.2] - 2021-09-02
 ### Added
 - Code documentation and additional test on subscribeToEvent
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dsnp/sdk",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dsnp/sdk",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@dsnp/contracts": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsnp/sdk",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "SDK Library for the DSNP",
   "type": "commonjs",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
## [3.0.2] - 2021-09-02
### Added
- Code documentation and additional test on subscribeToEvent

### Fixed
- subscribeToEvent zero value for fromBlock param fetches logs starting at zero
- batch.openURL to coerce URL to string before passing to ParquetJS
- Fixed flaky tests around registry