### PR TITLE
Config DSNP start block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Added
 - `dsnpStartBlockNumber` to config to allow setConfig to default a different value than `0` for `fromBlock`
+- Support "dsnp-start-block" for subscriptions to start from the `dsnpStartBlockNumber`
 
 ### Changed
 - Removed esmodule build. All imports will fallback to esmodule compatible commonjs modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+### Added
+- `dsnpStartBlockNumber` to config to allow setConfig to default a different value than `0` for `fromBlock`
+
 ### Changed
 - Removed esmodule build. All imports will fallback to esmodule compatible commonjs modules
 - Better cleaner build (removed multimodule script need, dist package directory, and better package.json)

--- a/src/core/config/config.test.ts
+++ b/src/core/config/config.test.ts
@@ -1,5 +1,12 @@
 import { providers, Wallet } from "ethers";
-import { getConfig, requireGetCurrentFromURI, requireGetProvider, requireGetSigner, requireGetStore } from "./config";
+import {
+  getConfig,
+  requireGetCurrentFromURI,
+  requireGetDsnpStartBlockNumber,
+  requireGetProvider,
+  requireGetSigner,
+  requireGetStore
+} from "./config";
 import {
   MissingStoreConfigError,
   MissingSignerConfigError,
@@ -39,5 +46,13 @@ describe("config", () => {
       const testRegistration = "0xabcd1234";
       expect(requireGetCurrentFromURI({ currentFromURI: testRegistration })).toEqual(testRegistration);
     });
+
+    it("returns the dsnp start block", () => {
+      expect(requireGetDsnpStartBlockNumber({dsnpStartBlockNumber: 100})).toEqual(100);
+    })
+
+    it("still returns zero for the dsnp start block", () => {
+      expect(requireGetDsnpStartBlockNumber(badConfig)).toEqual(0);
+    })
   });
 });

--- a/src/core/config/config.test.ts
+++ b/src/core/config/config.test.ts
@@ -5,7 +5,7 @@ import {
   requireGetDsnpStartBlockNumber,
   requireGetProvider,
   requireGetSigner,
-  requireGetStore
+  requireGetStore,
 } from "./config";
 import {
   MissingStoreConfigError,
@@ -48,11 +48,11 @@ describe("config", () => {
     });
 
     it("returns the dsnp start block", () => {
-      expect(requireGetDsnpStartBlockNumber({dsnpStartBlockNumber: 100})).toEqual(100);
-    })
+      expect(requireGetDsnpStartBlockNumber({ dsnpStartBlockNumber: 100 })).toEqual(100);
+    });
 
     it("still returns zero for the dsnp start block", () => {
       expect(requireGetDsnpStartBlockNumber(badConfig)).toEqual(0);
-    })
+    });
   });
 });

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -136,12 +136,12 @@ export const requireGetCurrentFromURI = (opts?: ConfigOpts): HexString => {
 /**
  * Get the default start block number
  *
- * @param opts
+ * @param opts - overrides for the current configuration.
  * @returns the block tag for ethers
  */
 export const requireGetDsnpStartBlockNumber = (opts?: ConfigOpts): number => {
   return opts?.dsnpStartBlockNumber || getConfig().dsnpStartBlockNumber || 0;
-}
+};
 
 /**
  * Get the contracts

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -46,7 +46,7 @@ export interface Config {
   contracts: Contracts;
   /** currentFromURI stores the id of the currently authenticated user */
   currentFromURI?: HexString;
-  /** dsnpStartBlockNumber defaults fromBlock to something other than the zero/genesis block */
+  /** dsnpStartBlockNumber defaults fromBlock to something other than the zero/genesis block or for "dsnp-start-block" */
   dsnpStartBlockNumber?: number;
   /** to allow access of keys by name */
   [index: string]: unknown;
@@ -135,6 +135,7 @@ export const requireGetCurrentFromURI = (opts?: ConfigOpts): HexString => {
 
 /**
  * Get the default start block number
+ * Used for "dsnp-start-block" or when the default is the genesis block
  *
  * @param opts - overrides for the current configuration.
  * @returns the block tag for ethers

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -46,6 +46,8 @@ export interface Config {
   contracts: Contracts;
   /** currentFromURI stores the id of the currently authenticated user */
   currentFromURI?: HexString;
+  /** dsnpStartBlockNumber defaults fromBlock to something other than the zero/genesis block */
+  dsnpStartBlockNumber?: number;
   /** to allow access of keys by name */
   [index: string]: unknown;
 }
@@ -130,6 +132,16 @@ export const requireGetCurrentFromURI = (opts?: ConfigOpts): HexString => {
   if (!currentFromURI) throw new MissingFromIdConfigError();
   return currentFromURI;
 };
+
+/**
+ * Get the default start block number
+ *
+ * @param opts
+ * @returns the block tag for ethers
+ */
+export const requireGetDsnpStartBlockNumber = (opts?: ConfigOpts): number => {
+  return opts?.dsnpStartBlockNumber || getConfig().dsnpStartBlockNumber || 0;
+}
 
 /**
  * Get the contracts

--- a/src/core/contracts/contract.test.ts
+++ b/src/core/contracts/contract.test.ts
@@ -1,6 +1,7 @@
 import { ethers } from "ethers";
 
 import { ContractName } from "../config";
+import { setConfig } from "../../config";
 import { getContractAddress } from "./contract";
 import { MissingContractAddressError } from "./errors";
 import { setupConfig } from "../../test/sdkTestConfig";
@@ -21,6 +22,11 @@ describe("Contracts", () => {
 
     it("throws MissingContractAddressError if no values found", async () => {
       await expect(getContractAddress(provider, "Test" as ContractName)).rejects.toThrow(MissingContractAddressError);
+    });
+
+    it("cannot find anything if the dsnp start block is too high", async () => {
+      setConfig({ dsnpStartBlockNumber: 1000000 });
+      await expect(getContractAddress(provider, "Publisher")).rejects.toThrow(MissingContractAddressError);
     });
   });
 });

--- a/src/core/contracts/contract.ts
+++ b/src/core/contracts/contract.ts
@@ -1,7 +1,7 @@
 import { JsonFragment } from "@ethersproject/abi";
 import { ethers } from "ethers";
 
-import { getContracts, ContractName, ConfigOpts } from "../config";
+import { getContracts, ContractName, ConfigOpts, requireGetDsnpStartBlockNumber } from "../config";
 import { MissingContractAddressError, NoLogsFoundContractError } from "./errors";
 import { HexString } from "../../types/Strings";
 import * as types from "../../types/typechain";
@@ -88,7 +88,7 @@ const filterValues = (values: ContractResult[], contractName: string): ContractR
  * @param provider - initialized provider
  * @param contractName - Name of contract to find address for
  * @param opts - Optional. Configuration overrides, such as from address, if any
- * @returns HexString A hexidecimal string representing the contract address
+ * @returns HexString A hexadecimal string representing the contract address
  */
 export const getContractAddress = async (
   provider: ethers.providers.Provider,
@@ -100,10 +100,9 @@ export const getContractAddress = async (
   if (contractOverrides[contractName] !== undefined) return contractOverrides[contractName]!;
 
   const topic = hash(DSNP_MIGRATION_TYPE);
-
   const logs: ethers.providers.Log[] = await provider.getLogs({
     topics: [topic],
-    fromBlock: 0,
+    fromBlock: requireGetDsnpStartBlockNumber(opts),
   });
   const decodedValues = decodeReturnValues(DSNP_MIGRATION_ABI, logs);
   const filteredResults = filterValues(decodedValues, contractName);

--- a/src/core/contracts/identity.ts
+++ b/src/core/contracts/identity.ts
@@ -1,5 +1,5 @@
 import { ContractTransaction, ethers } from "ethers";
-import { ConfigOpts, requireGetProvider, requireGetSigner } from "../config";
+import { ConfigOpts, requireGetDsnpStartBlockNumber, requireGetProvider, requireGetSigner } from "../config";
 import { EthereumAddress, HexString } from "../../types/Strings";
 import {
   IdentityCloneFactory,
@@ -470,7 +470,7 @@ export const getAllDelegateLogsFor = async (
 
   const logs: ethers.providers.Log[] = await provider.getLogs({
     topics: [[removeDelegateEventSignature, addDelegateEventSignature], [ethers.utils.hexZeroPad(ethereumAddress, 32)]],
-    fromBlock: 0,
+    fromBlock: requireGetDsnpStartBlockNumber(opts),
   });
 
   return logs.map((log: ethers.providers.Log) => {

--- a/src/core/contracts/registry.ts
+++ b/src/core/contracts/registry.ts
@@ -16,7 +16,7 @@ import {
   serialize,
 } from "../announcements";
 import { convertToDSNPUserId, convertToDSNPUserURI, DSNPUserId, DSNPUserURI } from "../identifiers";
-import { LogEventData } from "./utilities";
+import { FromBlockNumber, getFromBlockDefault, LogEventData } from "./utilities";
 import { isString } from "../utilities/validation";
 
 const CONTRACT_NAME = "Registry";
@@ -41,8 +41,8 @@ export type RegistryUpdateLogData = LogEventData & Registration;
 export interface RegistryUpdateFilterOptions {
   contractAddr?: EthereumAddress;
   dsnpUserURI?: DSNPUserURI;
-  fromBlock?: number;
-  endBlock?: number;
+  fromBlock?: FromBlockNumber;
+  endBlock?: ethers.providers.BlockTag;
 }
 
 /**
@@ -170,7 +170,9 @@ export const getDSNPRegistryUpdateEvents = async (
   const userId = filter.dsnpUserURI ? convertToDSNPUserId(filter.dsnpUserURI) : undefined;
   const eventFilter: ethers.EventFilter = contract.filters.DSNPRegistryUpdate(userId, filter.contractAddr);
 
-  const logs = await contract.queryFilter(eventFilter, filter.fromBlock, filter.endBlock);
+  const fromBlock = getFromBlockDefault(filter.fromBlock, 0);
+
+  const logs = await contract.queryFilter(eventFilter, fromBlock, filter.endBlock);
 
   return logs.map((desc) => {
     const [id, addr, handle] = desc.args;

--- a/src/core/contracts/registry.ts
+++ b/src/core/contracts/registry.ts
@@ -157,7 +157,7 @@ export const changeHandle = async (
  * Thrown if the provider is not configured.
  * @throws {@link MissingContractAddressError}
  * Thrown if the registration contract address cannot be found.
- * @param filter - By dsnpUserURI or Contract Address
+ * @param filter - By dsnpUserURI or Contract Address (supports fromBlock: "latest" | "dsnp-start-block" | number)
  * @param opts - (optional) any config overrides.
  * @returns An array of all the matching events
  */

--- a/src/core/contracts/subscription.ts
+++ b/src/core/contracts/subscription.ts
@@ -52,7 +52,7 @@ export type BatchPublicationCallback = (doReceivePublication: BatchPublicationLo
  * @throws {@link MissingProviderConfigError}
  * Thrown if the provider is not configured.
  * @param doReceivePublication - The callback function to be called when an event is received
- * @param filter - Any filter options for including or excluding certain events
+ * @param filter - Any filter options for including or excluding certain events (supports fromBlock: "latest" | "dsnp-start-block" | number)
  * @returns A function that can be called to remove listener for this type of event
  */
 export const subscribeToBatchPublications = async (
@@ -113,7 +113,7 @@ export type RegistryUpdateCallback = (doReceiveRegistryUpdate: RegistryUpdateLog
  * subscribeToRegistryUpdates() sets up a listener to retrieve DSNPRegistryUpdate events
  *
  * @param doReceiveRegistryUpdate - The callback function to be called when an event is received
- * @param filter - Filter options for including or excluding certain events
+ * @param filter - Filter options for including or excluding certain events (supports fromBlock: "latest" | "dsnp-start-block" | number)
  * @param opts - Optional. Configuration overrides, such as from address, if any
  * @returns A function that can be called to remove listener for this type of event
  */

--- a/src/core/contracts/subscription.ts
+++ b/src/core/contracts/subscription.ts
@@ -4,7 +4,7 @@ import { ConfigOpts, requireGetProvider } from "../config";
 import { dsnpBatchFilter } from "./publisher";
 import { Publisher__factory } from "../../types/typechain";
 import { LogDescription } from "@ethersproject/abi";
-import { LogEventData, subscribeToEvent, UnsubscribeFunction } from "./utilities";
+import { FromBlockNumber, getFromBlockDefault, LogEventData, subscribeToEvent, UnsubscribeFunction } from "./utilities";
 import { RegistryUpdateLogData, getContract } from "./registry";
 import { Registry } from "../../types/typechain";
 import { convertToDSNPUserURI } from "../identifiers";
@@ -35,7 +35,7 @@ export interface ParsedLog {
 
 export interface BatchFilterOptions {
   announcementType?: number;
-  fromBlock?: number;
+  fromBlock?: FromBlockNumber;
 }
 
 /**
@@ -68,7 +68,7 @@ export const subscribeToBatchPublications = async (
 
   const batchFilter: ethers.EventFilter = dsnpBatchFilter(filter?.announcementType);
 
-  return subscribeToEvent(provider, batchFilter, doReceiveEvent, filter?.fromBlock);
+  return subscribeToEvent(provider, batchFilter, doReceiveEvent, getFromBlockDefault(filter?.fromBlock, "latest"));
 };
 
 const decodeLogsForBatchPublication = (logs: ethers.providers.Log[]): BatchPublicationLogData[] => {
@@ -101,7 +101,7 @@ const decodeLogsForBatchPublication = (logs: ethers.providers.Log[]): BatchPubli
  * RegistryUpdateSubscriptionFilter filter options for including or excluding certain events
  */
 export interface RegistryUpdateSubscriptionFilter {
-  fromBlock?: number;
+  fromBlock?: FromBlockNumber;
 }
 
 /**
@@ -132,7 +132,12 @@ export const subscribeToRegistryUpdates = async (
     doReceiveRegistryUpdate(logItem);
   };
 
-  return subscribeToEvent(provider, registryUpdateFilter, doReceiveEvent, filter?.fromBlock);
+  return subscribeToEvent(
+    provider,
+    registryUpdateFilter,
+    doReceiveEvent,
+    getFromBlockDefault(filter?.fromBlock, "latest")
+  );
 };
 
 const decodeLogsForRegistryUpdate = (logs: ethers.providers.Log[], contract: Registry): RegistryUpdateLogData[] => {

--- a/src/core/contracts/utilities.test.ts
+++ b/src/core/contracts/utilities.test.ts
@@ -1,7 +1,8 @@
 import { ethers } from "ethers";
 
-import { subscribeToEvent } from "./utilities";
+import { getFromBlockDefault, subscribeToEvent } from "./utilities";
 import { checkNumberOfFunctionCalls } from "../../test/utilities";
+import { setConfig } from "../config";
 
 type ProviderOnCb = (log: ethers.providers.Log) => void;
 
@@ -167,5 +168,26 @@ describe("#subscribeToEvent", () => {
         });
       });
     });
+  });
+});
+
+describe("#getFromBlockDefault", () => {
+  it("defaults to the default", () => {
+    expect(getFromBlockDefault(undefined, 0)).toEqual(0);
+    expect(getFromBlockDefault(undefined, "latest")).toEqual("latest");
+  });
+
+  it("earliest converts to zero", () => {
+    expect(getFromBlockDefault("earliest", 0)).toEqual(0);
+  });
+
+  it("gets the value from the config", () => {
+    setConfig({ dsnpStartBlockNumber: 22, contracts: {} });
+    expect(getFromBlockDefault("dsnp-start-block", 0)).toEqual(22);
+  });
+
+  it("returns the given value", () => {
+    setConfig({ dsnpStartBlockNumber: 22, contracts: {} });
+    expect(getFromBlockDefault(100, 0)).toEqual(100);
   });
 });

--- a/src/core/contracts/utilities.ts
+++ b/src/core/contracts/utilities.ts
@@ -120,7 +120,7 @@ export const getFromBlockDefault = (
  * @param provider - initialized provider
  * @param filter - a filter to filter block events
  * @param doReceiveEvent - a callback that handles incoming event logs
- * @param fromBlock - a block number to start receiving event logs. Defaults to "latest"
+ * @param fromBlock - a block number to start receiving event logs. Defaults to "latest", supports number or "dsnp-start-block"
  * @returns An unsubscribe function
  */
 export const subscribeToEvent = async (

--- a/src/test/customMatchers.ts
+++ b/src/test/customMatchers.ts
@@ -1,15 +1,6 @@
 import { ContractTransaction } from "ethers";
 import { getVmError } from "../core/contracts/contract";
 
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace jest {
-    interface Matchers<R> {
-      transactionRejectsWith(message: string | RegExp): R;
-    }
-  }
-}
-
 expect.extend({
   async transactionRejectsWith(pendingTx: Promise<ContractTransaction>, message: string | RegExp) {
     try {

--- a/src/types/jest.d.ts
+++ b/src/types/jest.d.ts
@@ -1,0 +1,8 @@
+export {};
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      transactionRejectsWith(message: string | RegExp): R;
+    }
+  }
+}


### PR DESCRIPTION
Problem
=======
As a user of the SDK on a long running network, I don't want to search through millions of blocks I don't care about to get the data. I also don't want to have to manually set the default everywhere I call. I just want a config variable to do that work for me.
[PT #179564954](https://www.pivotaltracker.com/story/show/179564954)

Solution
========
Added an optional config param `dsnpStartBlockNumber` that will get used as the default as genesis instead of the chain genesis.

Double Checks:
---------------
- [x] Did you update the changelog?
- [x] Any new modules need to be exported?
- [x] Are new methods in the right module?
- [x] Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [x] Do you have good documentation on exported methods?

Change summary:
---------------
* Add optional config for `dsnpStartBlockNumber`
* Update methods to use the new `dsnpStartBlockNumber`
* Update `transactionRejectsWith` type which was broken for some IDEs

Also added an example and suggested values in https://github.com/LibertyDSNP/sdk-ts/pull/172