### PR TITLE
Feature/default config start block (Part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `dsnpStartBlockNumber` to config to allow setConfig to default a different value than `0` for `fromBlock`
 - Support "dsnp-start-block" for subscriptions to start from the `dsnpStartBlockNumber`
 - Readme configs for Rinkeby and Ropsten
+- `getDSNPRegistryUpdateEvents` defaults to dsnp-start-block
 
 ### Changed
 - Removed esmodule build. All imports will fallback to esmodule compatible commonjs modules

--- a/src/core/contracts/identity.test.ts
+++ b/src/core/contracts/identity.test.ts
@@ -53,9 +53,7 @@ describe("identity", () => {
     ({ provider, signer } = setupConfig());
   });
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+  beforeEach(jest.clearAllMocks);
 
   const getBeacon = async (): Promise<string> => {
     const addr = await getContractAddress(provider, "Beacon");

--- a/src/core/contracts/registry.test.ts
+++ b/src/core/contracts/registry.test.ts
@@ -29,6 +29,7 @@ import {
 import { generateHexString } from "@dsnp/test-generators";
 import { DSNPUserURI } from "../identifiers";
 import { EthereumAddress } from "../../types/Strings";
+import * as utilities from "./utilities";
 
 describe("registry", () => {
   let signer: Signer;
@@ -397,6 +398,12 @@ describe("registry", () => {
 
       expect(result).toEqual(expected);
       expect(result).toEqual(expectedTwo);
+    });
+
+    it("defaults to using dsnp-start-block", async () => {
+      (utilities.getFromBlockDefault as unknown) = jest.fn();
+      await getDSNPRegistryUpdateEvents({ dsnpUserURI: "" });
+      expect(utilities.getFromBlockDefault).toHaveBeenCalledWith(undefined, "dsnp-start-block");
     });
   });
 

--- a/src/core/contracts/registry.ts
+++ b/src/core/contracts/registry.ts
@@ -157,7 +157,7 @@ export const changeHandle = async (
  * Thrown if the provider is not configured.
  * @throws {@link MissingContractAddressError}
  * Thrown if the registration contract address cannot be found.
- * @param filter - By dsnpUserURI or Contract Address (supports fromBlock: "latest" | "dsnp-start-block" | number)
+ * @param filter - By dsnpUserURI or Contract Address (supports fromBlock: "latest" | "dsnp-start-block" (default) | number)
  * @param opts - (optional) any config overrides.
  * @returns An array of all the matching events
  */
@@ -170,7 +170,7 @@ export const getDSNPRegistryUpdateEvents = async (
   const userId = filter.dsnpUserURI ? convertToDSNPUserId(filter.dsnpUserURI) : undefined;
   const eventFilter: ethers.EventFilter = contract.filters.DSNPRegistryUpdate(userId, filter.contractAddr);
 
-  const fromBlock = getFromBlockDefault(filter.fromBlock, 0);
+  const fromBlock = getFromBlockDefault(filter.fromBlock, "dsnp-start-block");
 
   const logs = await contract.queryFilter(eventFilter, fromBlock, filter.endBlock);
 

--- a/src/core/contracts/subscription.ts
+++ b/src/core/contracts/subscription.ts
@@ -52,7 +52,7 @@ export type BatchPublicationCallback = (doReceivePublication: BatchPublicationLo
  * @throws {@link MissingProviderConfigError}
  * Thrown if the provider is not configured.
  * @param doReceivePublication - The callback function to be called when an event is received
- * @param filter - Any filter options for including or excluding certain events (supports fromBlock: "latest" | "dsnp-start-block" | number)
+ * @param filter - Any filter options for including or excluding certain events (supports fromBlock: "latest" (default) | "dsnp-start-block" | number)
  * @returns A function that can be called to remove listener for this type of event
  */
 export const subscribeToBatchPublications = async (
@@ -113,7 +113,7 @@ export type RegistryUpdateCallback = (doReceiveRegistryUpdate: RegistryUpdateLog
  * subscribeToRegistryUpdates() sets up a listener to retrieve DSNPRegistryUpdate events
  *
  * @param doReceiveRegistryUpdate - The callback function to be called when an event is received
- * @param filter - Filter options for including or excluding certain events (supports fromBlock: "latest" | "dsnp-start-block" | number)
+ * @param filter - Filter options for including or excluding certain events (supports fromBlock: "latest" (default) | "dsnp-start-block" | number)
  * @param opts - Optional. Configuration overrides, such as from address, if any
  * @returns A function that can be called to remove listener for this type of event
  */

--- a/src/core/contracts/utilities.test.ts
+++ b/src/core/contracts/utilities.test.ts
@@ -175,6 +175,7 @@ describe("#getFromBlockDefault", () => {
   it("defaults to the default", () => {
     expect(getFromBlockDefault(undefined, 0)).toEqual(0);
     expect(getFromBlockDefault(undefined, "latest")).toEqual("latest");
+    expect(getFromBlockDefault(undefined, "dsnp-start-block", { dsnpStartBlockNumber: 10 })).toEqual(10);
   });
 
   it("earliest converts to zero", () => {

--- a/src/core/contracts/utilities.ts
+++ b/src/core/contracts/utilities.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 import { HexString } from "../../types/Strings";
-import { requireGetDsnpStartBlockNumber } from "../config";
+import { ConfigOpts, requireGetDsnpStartBlockNumber } from "../config";
 
 /**
  * DomainData represents EIP-712 unique domain
@@ -99,17 +99,22 @@ export type FromBlockNumber = number | "dsnp-start-block" | "latest" | "earliest
  * Convert a user block value to an actual block number.
  * Defaults to "latest" for subscription needs
  *
- * @param userFromBlock - undefined results in using defaultZeroOrLatest
- * @param defaultZeroOrLatest - undefined = latest or 0?
+ * @param userFromBlock - undefined results in using defaultTo
+ * @param defaultTo - undefined = latest or 0 or dsnp-start-block?
+ * @param opts - (optional) any config overrides.
  * @returns A block number or "latest"
  */
 export const getFromBlockDefault = (
   userFromBlock: FromBlockNumber | undefined,
-  defaultZeroOrLatest: 0 | "latest"
+  defaultTo: 0 | "latest" | "dsnp-start-block",
+  opts?: ConfigOpts
 ): number | "latest" => {
-  if (userFromBlock === undefined) return defaultZeroOrLatest;
+  if (userFromBlock === undefined) {
+    if (defaultTo === "dsnp-start-block") return requireGetDsnpStartBlockNumber(opts);
+    return defaultTo;
+  }
   if (userFromBlock === "earliest") return 0;
-  if (userFromBlock === "dsnp-start-block") return requireGetDsnpStartBlockNumber();
+  if (userFromBlock === "dsnp-start-block") return requireGetDsnpStartBlockNumber(opts);
   return userFromBlock;
 };
 


### PR DESCRIPTION
Problem
=======
While #171 got most of the places, I missed one. `getDSNPRegistryUpdateEvents` was still defaulting to origin instead of dsnp-start block.

[#12345678](https://www.pivotaltracker.com/story/show/179564954)

Solution
========
Make getDSNPRegistryUpdateEvents default to dsnp-start-block

Double Checks:
---------------
- [x] Did you update the changelog?
- [x] Any new modules need to be exported?
- [x] Are new methods in the right module?
- [x] Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [x] Do you have good documentation on exported methods?

Change summary:
---------------
* Update docs to be more clear about what the default is for different methods
* getFromBlockDefault supports opts and defaulting to dsnp-start-block
* Default getDSNPRegistryUpdateEvents to dsnp-start-block