### PR TITLE
v3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+
+## [3.0.3] - 2021-09-15
 ### Added
 - `dsnpStartBlockNumber` to config to allow setConfig to default a different value than `0` for `fromBlock`
 - Support "dsnp-start-block" for subscriptions to start from the `dsnpStartBlockNumber`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dsnp/sdk",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dsnp/sdk",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@dsnp/contracts": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsnp/sdk",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "SDK Library for the DSNP",
   "type": "commonjs",
   "main": "dist/index.js",


### PR DESCRIPTION
## [3.0.3] - 2021-09-15
### Added
- `dsnpStartBlockNumber` to config to allow setConfig to default a different value than `0` for `fromBlock`
- Support "dsnp-start-block" for subscriptions to start from the `dsnpStartBlockNumber`
- Readme configs for Rinkeby and Ropsten
- `getDSNPRegistryUpdateEvents` defaults to dsnp-start-block

### Changed
- Removed esmodule build. All imports will fallback to esmodule compatible commonjs modules
- Better cleaner build (removed multimodule script need, dist package directory, and better package.json)

### Removed
- Internal package `dist` structure. If you were previously importing out of `@dsnp/sdk/dist`, that will need to be updated to the correct export. 
