### PR TITLE
Feature/fetch logs paged

### DIFF
--- a/src/core/contracts/contract.ts
+++ b/src/core/contracts/contract.ts
@@ -11,7 +11,7 @@ const DSNP_MIGRATION_TYPE = "DSNPMigration(address,string)";
 
 type RawLog = { topics: Array<string>; data: string };
 
-const EVENTS_ABI = new ethers.utils.Interface(
+export const EVENTS_ABI = new ethers.utils.Interface(
   [
     types.Publisher__factory,
     types.BeaconFactory__factory,

--- a/src/core/contracts/subscription.test.ts
+++ b/src/core/contracts/subscription.test.ts
@@ -1,21 +1,19 @@
-import {requireGetProvider} from "../config";
-import {dsnpBatchFilter, Publication, publish} from "./publisher";
+import { requireGetProvider } from "../config";
+import { dsnpBatchFilter, Publication, publish } from "./publisher";
 import {
-  AsyncIterator,
   BatchFilterOptions,
   BatchPublicationLogData,
   subscribeToBatchPublications,
   subscribeToRegistryUpdates,
-  syncPublicationsByRange,
 } from "./subscription";
-import {setupSnapshot} from "../../test/hardhatRPC";
-import {setupConfig} from "../../test/sdkTestConfig";
-import {checkNumberOfFunctionCalls, mineBlocks} from "../../test/utilities";
-import {hash} from "../utilities";
-import {ethers, Signer} from "ethers";
-import {changeHandle, getContract, register} from "./registry";
-import {Identity__factory, Registry} from "../../types/typechain";
-import {JsonRpcProvider} from "@ethersproject/providers";
+import { setupSnapshot } from "../../test/hardhatRPC";
+import { setupConfig } from "../../test/sdkTestConfig";
+import { checkNumberOfFunctionCalls, mineBlocks } from "../../test/utilities";
+import { hash } from "../utilities";
+import { ethers, Signer } from "ethers";
+import { changeHandle, getContract, register } from "./registry";
+import { Identity__factory, Registry } from "../../types/typechain";
+import { JsonRpcProvider } from "@ethersproject/providers";
 
 describe("subscription", () => {
   setupSnapshot();
@@ -38,7 +36,7 @@ describe("subscription", () => {
       const mock = jest.fn();
 
       const removeListener = await subscribeToBatchPublications(mock);
-      const publications: Publication[] = [{announcementType: 2, fileUrl: testUrl, fileHash}];
+      const publications: Publication[] = [{ announcementType: 2, fileUrl: testUrl, fileHash }];
       await (await publish(publications)).wait(1);
       const numberOfCalls = await checkNumberOfFunctionCalls(mock, 30, 1);
 
@@ -63,8 +61,8 @@ describe("subscription", () => {
       const mock = jest.fn();
 
       const removeListener = await subscribeToBatchPublications(mock);
-      const publications: Publication[] = [{announcementType: 2, fileUrl: testUrl1, fileHash: hash1}];
-      const publications1: Publication[] = [{announcementType: 2, fileUrl: testUrl2, fileHash: hash2}];
+      const publications: Publication[] = [{ announcementType: 2, fileUrl: testUrl1, fileHash: hash1 }];
+      const publications1: Publication[] = [{ announcementType: 2, fileUrl: testUrl2, fileHash: hash2 }];
       await (await publish(publications)).wait(1);
       await (await publish(publications1)).wait(1);
       const numberOfCalls = await checkNumberOfFunctionCalls(mock, 10, 2);
@@ -115,13 +113,13 @@ describe("subscription", () => {
 
           const testUrl = "http://www.test.com";
           const fileHash = hash("test");
-          const publications1: Publication[] = [{announcementType: 2, fileUrl: testUrl, fileHash: fileHash}];
+          const publications1: Publication[] = [{ announcementType: 2, fileUrl: testUrl, fileHash: fileHash }];
           await (await publish(publications1)).wait(1);
           await new Promise((r) => setTimeout(r, 2000));
 
           await mineBlocks(11, provider as ethers.providers.JsonRpcProvider);
 
-          const publications: Publication[] = [{announcementType: 2, fileUrl: testUrl, fileHash: fileHash}];
+          const publications: Publication[] = [{ announcementType: 2, fileUrl: testUrl, fileHash: fileHash }];
 
           await (await publish(publications)).wait(1);
 
@@ -161,9 +159,9 @@ describe("subscription", () => {
       const testUrl4 = "http://www.testconst333.com";
       const hash4 = hash("test333");
 
-      const removeListener = await subscribeToBatchPublications(mock, {announcementType: 2});
-      const publications: Publication[] = [{announcementType: 2, fileUrl: testUrl3, fileHash: hash3}];
-      const publications1: Publication[] = [{announcementType: 4, fileUrl: testUrl4, fileHash: hash4}];
+      const removeListener = await subscribeToBatchPublications(mock, { announcementType: 2 });
+      const publications: Publication[] = [{ announcementType: 2, fileUrl: testUrl3, fileHash: hash3 }];
+      const publications1: Publication[] = [{ announcementType: 4, fileUrl: testUrl4, fileHash: hash4 }];
       await (await publish(publications)).wait(1);
       await (await publish(publications1)).wait(1);
       await checkNumberOfFunctionCalls(mock, 10, 1);
@@ -191,17 +189,17 @@ describe("subscription", () => {
       const testUrl6 = "http://www.testconst666.com";
       const hash6 = hash("test666");
 
-      const publications: Publication[] = [{announcementType: 2, fileUrl: testUrl3, fileHash: hash3}];
-      const publications1: Publication[] = [{announcementType: 2, fileUrl: testUrl4, fileHash: hash4}];
-      const publications2: Publication[] = [{announcementType: 2, fileUrl: testUrl5, fileHash: hash5}];
-      const publications3: Publication[] = [{announcementType: 2, fileUrl: testUrl6, fileHash: hash6}];
+      const publications: Publication[] = [{ announcementType: 2, fileUrl: testUrl3, fileHash: hash3 }];
+      const publications1: Publication[] = [{ announcementType: 2, fileUrl: testUrl4, fileHash: hash4 }];
+      const publications2: Publication[] = [{ announcementType: 2, fileUrl: testUrl5, fileHash: hash5 }];
+      const publications3: Publication[] = [{ announcementType: 2, fileUrl: testUrl6, fileHash: hash6 }];
 
       await (await publish(publications)).wait(1);
 
       const blockNumber = (await provider.getBlockNumber()) + 1;
       await (await publish(publications1)).wait(1);
 
-      const removeListener = await subscribeToBatchPublications(mock, {announcementType: 2, fromBlock: blockNumber});
+      const removeListener = await subscribeToBatchPublications(mock, { announcementType: 2, fromBlock: blockNumber });
 
       await (await publish(publications2)).wait(1);
       await (await publish(publications3)).wait(1);
@@ -253,7 +251,7 @@ describe("subscription", () => {
       setupSnapshot();
 
       beforeAll(() => {
-        ({signer, provider} = setupConfig());
+        ({ signer, provider } = setupConfig());
       });
 
       it("retrieves past events based on given start block", async () => {
@@ -278,7 +276,7 @@ describe("subscription", () => {
         await mineBlocks(10, provider as ethers.providers.JsonRpcProvider);
         await (await changeHandle(handleTwo, handleThree)).wait(1);
 
-        const removeListener = await subscribeToRegistryUpdates(mock, {fromBlock: currentBlockNumber});
+        const removeListener = await subscribeToRegistryUpdates(mock, { fromBlock: currentBlockNumber });
         await checkNumberOfFunctionCalls(mock, 10, 3);
 
         expect(mock).toHaveBeenCalledTimes(3);
@@ -321,73 +319,4 @@ describe("subscription", () => {
       });
     });
   });
-
-  describe("syncPublicationsByRange", () => {
-    let provider: ethers.providers.Provider;
-    let filter: ethers.EventFilter;
-    jest.setTimeout(7000);
-
-    const testUrl = "http://www.testconst.com";
-    const filenames = ["test00", "test01", "test02", "test03"];
-    const publications: Publication[] = [
-      {announcementType: 2, fileUrl: [testUrl, filenames[0]].join("/"), fileHash: hash(filenames[0])},
-      {announcementType: 2, fileUrl: [testUrl, filenames[1]].join("/"), fileHash: hash(filenames[1])},
-      {announcementType: 2, fileUrl: [testUrl, filenames[2]].join("/"), fileHash: hash(filenames[2])},
-      {announcementType: 2, fileUrl: [testUrl, filenames[3]].join("/"), fileHash: hash(filenames[3])},
-    ];
-
-    const rcpts: number[] = [];
-
-    beforeEach(async () => {
-      provider = requireGetProvider();
-      filter = dsnpBatchFilter(2);
-      for (const pub of publications) {
-        const txn = await publish([pub]);
-        const rcpt = await txn.wait(1);
-        rcpts.push(rcpt.blockNumber);
-        await mineBlocks(1, provider as ethers.providers.JsonRpcProvider);
-      }
-      await new Promise((r) => setTimeout(r, 2000));
-    });
-
-    describe("when only a filter + walkback is passed", () => {
-      let nextResult: IteratorResult<Publication>;
-      let iterator: AsyncIterator<Publication>;
-      beforeEach(async () => {
-        iterator = await syncPublicationsByRange(filter, 4);
-        nextResult = await iterator.next();
-      });
-
-      it("fetches chunks in the expected order", async () => {
-        for (const result of [2, 3, 0, 1]) {
-          expect(nextResult?.value?.fileHash).toEqual(publications[result].fileHash);
-          expect(nextResult?.value?.fileUrl).toEqual(publications[result].fileUrl);
-          expect(nextResult?.value?.blockNumber).toEqual(rcpts[result]);
-          nextResult = await iterator.next();
-        }
-        expect(nextResult?.done).toEqual(true);
-        expect(nextResult?.value).toBeUndefined();
-      });
-      describe("when parameters are passed", () => {
-        it("fetches only what is up to teh earliest block", async () => {
-          const earliestBlock = rcpts[2];
-          const latestBlock = rcpts[3];
-          const walkbackBlockCount = 2;
-          const iterator = await syncPublicationsByRange(filter, walkbackBlockCount, earliestBlock, latestBlock);
-          let nextResult = await iterator.next();
-          expect(nextResult?.done).toEqual(false);
-          expect(nextResult?.value.length).toEqual(2);
-          nextResult = await iterator.next();
-          expect(nextResult?.done).toEqual(true);
-          expect(nextResult?.value.length).toEqual(2);
-          nextResult = await iterator.next();
-          expect(nextResult?.done).toEqual(true);
-          expect(nextResult?.value.length).toEqual(0);
-        });
-
-        // it("fetches  specified by walkback", async () => {});
-        // it("fetches only up to the toBlock specified", async () => {});
-        // it("throws an error if walkbackBlockCount is invalid", async () => {});
-      });
-    });
-  });
+});

--- a/src/core/contracts/subscription.test.ts
+++ b/src/core/contracts/subscription.test.ts
@@ -1,21 +1,21 @@
-import { requireGetProvider } from "../config";
-import { publish, Publication, dsnpBatchFilter } from "./publisher";
+import {requireGetProvider} from "../config";
+import {dsnpBatchFilter, Publication, publish} from "./publisher";
 import {
-  subscribeToBatchPublications,
-  BatchPublicationLogData,
+  AsyncIterator,
   BatchFilterOptions,
+  BatchPublicationLogData,
+  subscribeToBatchPublications,
   subscribeToRegistryUpdates,
   syncPublicationsByRange,
-  AsyncIterator,
 } from "./subscription";
-import { setupSnapshot } from "../../test/hardhatRPC";
-import { setupConfig } from "../../test/sdkTestConfig";
-import { checkNumberOfFunctionCalls, mineBlocks } from "../../test/utilities";
-import { hash } from "../utilities";
-import { ethers, Signer } from "ethers";
-import { changeHandle, getContract, register } from "./registry";
-import { Identity__factory, Registry } from "../../types/typechain";
-import { JsonRpcProvider } from "@ethersproject/providers";
+import {setupSnapshot} from "../../test/hardhatRPC";
+import {setupConfig} from "../../test/sdkTestConfig";
+import {checkNumberOfFunctionCalls, mineBlocks} from "../../test/utilities";
+import {hash} from "../utilities";
+import {ethers, Signer} from "ethers";
+import {changeHandle, getContract, register} from "./registry";
+import {Identity__factory, Registry} from "../../types/typechain";
+import {JsonRpcProvider} from "@ethersproject/providers";
 
 describe("subscription", () => {
   setupSnapshot();
@@ -38,7 +38,7 @@ describe("subscription", () => {
       const mock = jest.fn();
 
       const removeListener = await subscribeToBatchPublications(mock);
-      const publications: Publication[] = [{ announcementType: 2, fileUrl: testUrl, fileHash }];
+      const publications: Publication[] = [{announcementType: 2, fileUrl: testUrl, fileHash}];
       await (await publish(publications)).wait(1);
       const numberOfCalls = await checkNumberOfFunctionCalls(mock, 30, 1);
 
@@ -63,8 +63,8 @@ describe("subscription", () => {
       const mock = jest.fn();
 
       const removeListener = await subscribeToBatchPublications(mock);
-      const publications: Publication[] = [{ announcementType: 2, fileUrl: testUrl1, fileHash: hash1 }];
-      const publications1: Publication[] = [{ announcementType: 2, fileUrl: testUrl2, fileHash: hash2 }];
+      const publications: Publication[] = [{announcementType: 2, fileUrl: testUrl1, fileHash: hash1}];
+      const publications1: Publication[] = [{announcementType: 2, fileUrl: testUrl2, fileHash: hash2}];
       await (await publish(publications)).wait(1);
       await (await publish(publications1)).wait(1);
       const numberOfCalls = await checkNumberOfFunctionCalls(mock, 10, 2);
@@ -115,13 +115,13 @@ describe("subscription", () => {
 
           const testUrl = "http://www.test.com";
           const fileHash = hash("test");
-          const publications1: Publication[] = [{ announcementType: 2, fileUrl: testUrl, fileHash: fileHash }];
+          const publications1: Publication[] = [{announcementType: 2, fileUrl: testUrl, fileHash: fileHash}];
           await (await publish(publications1)).wait(1);
           await new Promise((r) => setTimeout(r, 2000));
 
           await mineBlocks(11, provider as ethers.providers.JsonRpcProvider);
 
-          const publications: Publication[] = [{ announcementType: 2, fileUrl: testUrl, fileHash: fileHash }];
+          const publications: Publication[] = [{announcementType: 2, fileUrl: testUrl, fileHash: fileHash}];
 
           await (await publish(publications)).wait(1);
 
@@ -161,9 +161,9 @@ describe("subscription", () => {
       const testUrl4 = "http://www.testconst333.com";
       const hash4 = hash("test333");
 
-      const removeListener = await subscribeToBatchPublications(mock, { announcementType: 2 });
-      const publications: Publication[] = [{ announcementType: 2, fileUrl: testUrl3, fileHash: hash3 }];
-      const publications1: Publication[] = [{ announcementType: 4, fileUrl: testUrl4, fileHash: hash4 }];
+      const removeListener = await subscribeToBatchPublications(mock, {announcementType: 2});
+      const publications: Publication[] = [{announcementType: 2, fileUrl: testUrl3, fileHash: hash3}];
+      const publications1: Publication[] = [{announcementType: 4, fileUrl: testUrl4, fileHash: hash4}];
       await (await publish(publications)).wait(1);
       await (await publish(publications1)).wait(1);
       await checkNumberOfFunctionCalls(mock, 10, 1);
@@ -191,17 +191,17 @@ describe("subscription", () => {
       const testUrl6 = "http://www.testconst666.com";
       const hash6 = hash("test666");
 
-      const publications: Publication[] = [{ announcementType: 2, fileUrl: testUrl3, fileHash: hash3 }];
-      const publications1: Publication[] = [{ announcementType: 2, fileUrl: testUrl4, fileHash: hash4 }];
-      const publications2: Publication[] = [{ announcementType: 2, fileUrl: testUrl5, fileHash: hash5 }];
-      const publications3: Publication[] = [{ announcementType: 2, fileUrl: testUrl6, fileHash: hash6 }];
+      const publications: Publication[] = [{announcementType: 2, fileUrl: testUrl3, fileHash: hash3}];
+      const publications1: Publication[] = [{announcementType: 2, fileUrl: testUrl4, fileHash: hash4}];
+      const publications2: Publication[] = [{announcementType: 2, fileUrl: testUrl5, fileHash: hash5}];
+      const publications3: Publication[] = [{announcementType: 2, fileUrl: testUrl6, fileHash: hash6}];
 
       await (await publish(publications)).wait(1);
 
       const blockNumber = (await provider.getBlockNumber()) + 1;
       await (await publish(publications1)).wait(1);
 
-      const removeListener = await subscribeToBatchPublications(mock, { announcementType: 2, fromBlock: blockNumber });
+      const removeListener = await subscribeToBatchPublications(mock, {announcementType: 2, fromBlock: blockNumber});
 
       await (await publish(publications2)).wait(1);
       await (await publish(publications3)).wait(1);
@@ -253,7 +253,7 @@ describe("subscription", () => {
       setupSnapshot();
 
       beforeAll(() => {
-        ({ signer, provider } = setupConfig());
+        ({signer, provider} = setupConfig());
       });
 
       it("retrieves past events based on given start block", async () => {
@@ -278,7 +278,7 @@ describe("subscription", () => {
         await mineBlocks(10, provider as ethers.providers.JsonRpcProvider);
         await (await changeHandle(handleTwo, handleThree)).wait(1);
 
-        const removeListener = await subscribeToRegistryUpdates(mock, { fromBlock: currentBlockNumber });
+        const removeListener = await subscribeToRegistryUpdates(mock, {fromBlock: currentBlockNumber});
         await checkNumberOfFunctionCalls(mock, 10, 3);
 
         expect(mock).toHaveBeenCalledTimes(3);
@@ -330,10 +330,10 @@ describe("subscription", () => {
     const testUrl = "http://www.testconst.com";
     const filenames = ["test00", "test01", "test02", "test03"];
     const publications: Publication[] = [
-      { announcementType: 2, fileUrl: [testUrl, filenames[0]].join("/"), fileHash: hash(filenames[0]) },
-      { announcementType: 2, fileUrl: [testUrl, filenames[1]].join("/"), fileHash: hash(filenames[1]) },
-      { announcementType: 2, fileUrl: [testUrl, filenames[2]].join("/"), fileHash: hash(filenames[2]) },
-      { announcementType: 2, fileUrl: [testUrl, filenames[3]].join("/"), fileHash: hash(filenames[3]) },
+      {announcementType: 2, fileUrl: [testUrl, filenames[0]].join("/"), fileHash: hash(filenames[0])},
+      {announcementType: 2, fileUrl: [testUrl, filenames[1]].join("/"), fileHash: hash(filenames[1])},
+      {announcementType: 2, fileUrl: [testUrl, filenames[2]].join("/"), fileHash: hash(filenames[2])},
+      {announcementType: 2, fileUrl: [testUrl, filenames[3]].join("/"), fileHash: hash(filenames[3])},
     ];
 
     const rcpts: number[] = [];
@@ -350,48 +350,44 @@ describe("subscription", () => {
       await new Promise((r) => setTimeout(r, 2000));
     });
 
-    describe("when only a filter is passed", () => {
-      let nextResult: IteratorResult<Publication[]>;
-      let iterator: AsyncIterator<Publication[]>;
+    describe("when only a filter + walkback is passed", () => {
+      let nextResult: IteratorResult<Publication>;
+      let iterator: AsyncIterator<Publication>;
       beforeEach(async () => {
-        iterator = await syncPublicationsByRange({ filter });
+        iterator = await syncPublicationsByRange(filter, 4);
         nextResult = await iterator.next();
       });
 
-      it("fetches all blocks by default", () => {
+      it("fetches chunks in the expected order", async () => {
+        for (const result of [2, 3, 0, 1]) {
+          expect(nextResult?.value?.fileHash).toEqual(publications[result].fileHash);
+          expect(nextResult?.value?.fileUrl).toEqual(publications[result].fileUrl);
+          expect(nextResult?.value?.blockNumber).toEqual(rcpts[result]);
+          nextResult = await iterator.next();
+        }
         expect(nextResult?.done).toEqual(true);
-        expect(nextResult?.value).toHaveLength(4);
+        expect(nextResult?.value).toBeUndefined();
       });
-
-      it("subsequent calls to next return empty results", async () => {
-        nextResult = await iterator.next();
-        expect(nextResult).toEqual({
-          done: true,
-          value: [],
+      describe("when parameters are passed", () => {
+        it("fetches only what is up to teh earliest block", async () => {
+          const earliestBlock = rcpts[2];
+          const latestBlock = rcpts[3];
+          const walkbackBlockCount = 2;
+          const iterator = await syncPublicationsByRange(filter, walkbackBlockCount, earliestBlock, latestBlock);
+          let nextResult = await iterator.next();
+          expect(nextResult?.done).toEqual(false);
+          expect(nextResult?.value.length).toEqual(2);
+          nextResult = await iterator.next();
+          expect(nextResult?.done).toEqual(true);
+          expect(nextResult?.value.length).toEqual(2);
+          nextResult = await iterator.next();
+          expect(nextResult?.done).toEqual(true);
+          expect(nextResult?.value.length).toEqual(0);
         });
-      });
-    });
 
-    describe("when parameters are passed", () => {
-      it("fetches only the number of blocks specified by blockLimit", async () => {
-        const fromBlock = rcpts[0];
-        const toBlock = rcpts[3];
-        const blockLimit = 2;
-        const iterator = await syncPublicationsByRange({ filter, fromBlock, toBlock, blockLimit });
-        let nextResult = await iterator.next();
-        expect(nextResult?.done).toEqual(false);
-        expect(nextResult?.value.length).toEqual(2);
-        nextResult = await iterator.next();
-        expect(nextResult?.done).toEqual(true);
-        expect(nextResult?.value.length).toEqual(2);
-        nextResult = await iterator.next();
-        expect(nextResult?.done).toEqual(true);
-        expect(nextResult?.value.length).toEqual(0);
+        // it("fetches  specified by walkback", async () => {});
+        // it("fetches only up to the toBlock specified", async () => {});
+        // it("throws an error if walkbackBlockCount is invalid", async () => {});
       });
-
-      // it("fetches  specified by walkback", async () => {});
-      // it("fetches only up to the toBlock specified", async () => {});
-      // it("throws an error if walkbackBlockCount is invalid", async () => {});
     });
   });
-});

--- a/src/core/contracts/utilities.ts
+++ b/src/core/contracts/utilities.ts
@@ -1,6 +1,11 @@
 import { ethers } from "ethers";
 import { HexString } from "../../types/Strings";
-import { ConfigOpts, requireGetDsnpStartBlockNumber } from "../config";
+import { ConfigOpts, requireGetDsnpStartBlockNumber, requireGetProvider } from "../config";
+import { EventFilter } from "ethers/lib/ethers";
+import { Publication } from "./publisher";
+import { Log as EventLog } from "@ethersproject/abstract-provider";
+import { DSNPError } from "../errors";
+import { decodeLogsForBatchPublication } from "./subscription";
 
 /**
  * DomainData represents EIP-712 unique domain
@@ -180,4 +185,144 @@ export const subscribeToEvent = async (
   return () => {
     provider.off(filter);
   };
+};
+
+/**
+ * BlockRangeOptions for specifying chain filter and block limits.
+ *
+ * @member filter - an EventFilter
+ * @member walkbackBlocks - number of blocks to walk back at a time
+ * @member latestBlock - the latest block to start retrieving
+ * @member earliestBlock - the first block to stop retrieving
+ */
+interface BlockRangeOptions {
+  filter: EventFilter;
+  walkbackBlocks: number;
+  latestBlock: number;
+  earliestBlock: number;
+}
+
+export const MAX_WALKBACK = 10000;
+
+/**
+ *  AsyncPublicationsIterator is an AsyncIterator which implements only an async next() function.
+ *  Lazily fetches log events from the chain based on a Publications filter, walkbackBlocks
+ *  and a range of blocks provided in the constructor.  When logs are found, they are
+ *  decoded into Publications.
+ */
+export class AsyncPublicationsIterator {
+  earliestBlock: number;
+  walkbackBlocks: number;
+  currentStartBlock: number;
+  currentEndBlock: number;
+  logIndex: number;
+  publications: Array<Publication>;
+  provider: ethers.providers.Provider;
+  filter: EventFilter;
+
+  /**
+   *
+   * @param rangeOptions - BlockRangeOptions for fetching publications
+   * @param provider - ethers.providers.Provider
+   */
+  constructor(rangeOptions: BlockRangeOptions, provider: ethers.providers.Provider) {
+    this.earliestBlock = rangeOptions.earliestBlock;
+    this.walkbackBlocks = rangeOptions.walkbackBlocks;
+    this.currentEndBlock = rangeOptions.latestBlock;
+    this.currentStartBlock = rangeOptions.latestBlock - this.walkbackBlocks + 1;
+    this.filter = rangeOptions.filter;
+    this.provider = provider;
+    this.logIndex = 0;
+    this.publications = [];
+  }
+
+  reachedEarliestBlock(): boolean {
+    return this.currentEndBlock < this.earliestBlock;
+  }
+
+  // we should fetch logs from the chain initially or if we've returned the last item
+  // fetched last time.
+  shouldFetchLogs(): boolean {
+    return !this.publications.length || this.logIndex === this.publications.length - 1;
+  }
+
+  doneFetching(): boolean {
+    return this.reachedEarliestBlock() && this.logIndex === this.publications.length;
+  }
+
+  async fetchUntilGetLogsOrDone() {
+    let logs: EventLog[] = [];
+    // keep going until we get something or we hit the earliest requested block height.
+    while (!logs.length && !this.reachedEarliestBlock()) {
+      logs = await this.provider.getLogs({
+        topics: this.filter.topics,
+        fromBlock: this.currentStartBlock,
+        toBlock: this.currentEndBlock,
+      });
+      this.currentEndBlock = this.currentStartBlock - 1; // check off by 1
+      this.currentStartBlock = Math.max(this.currentStartBlock - this.walkbackBlocks, this.earliestBlock);
+    }
+    this.logIndex = 0;
+    this.publications = decodeLogsForBatchPublication(logs);
+  }
+
+  /**
+   * next - returns a Promise of an IteratorResult enclosing a Publication.
+   * IteratorResult = \{
+   *    done: true if the earliest block has been reached and the last Publication has
+   *          been returned via next().
+   *    value: a Publication
+   * \}
+   */
+  public async next(): Promise<IteratorResult<Publication>> {
+    if (this.shouldFetchLogs()) {
+      await this.fetchUntilGetLogsOrDone();
+    } else {
+      this.logIndex++;
+    }
+    return Promise.resolve({ done: this.doneFetching(), value: this.publications[this.logIndex] });
+  }
+}
+
+const requirePositive = (value: number, name: string) => {
+  if (value < 0) {
+    throw new DSNPError(`${name} must be > 0`);
+  }
+};
+
+const requireValidBlockRange = (newestBlock?: number, oldestBlock?: number) => {
+  if (newestBlock) requirePositive(newestBlock, "newestBlock");
+  if (oldestBlock) requirePositive(oldestBlock, "oldestBlock");
+  if (newestBlock && oldestBlock && oldestBlock >= newestBlock) {
+    throw new DSNPError("newestBlock must be greater than oldestBlock");
+  }
+};
+
+const requireValidWalkback = (walkbackBlocks: number) => {
+  requirePositive(walkbackBlocks, "walkbackBlocks");
+  if (walkbackBlocks > MAX_WALKBACK) throw new DSNPError("walkbackBlocks must be <= " + MAX_WALKBACK);
+};
+
+/**
+ * getPublicationLogIterator fetches filtered logs based on the provided filter, in the range specified.
+ *
+ * @param filter - is an ethers EventFilter. It is required.
+ * @param  walkbackBlocks - is a number. It is required and must be :gt; 0 and &lt; MAX_WALKBACK
+ * @param newestBlock - is a number. It is optional and must be :gt;0.  It defaults to the current block height.
+ * @param oldestBlock - is a number. It is optional, must be :ge;0 , and defaults to 0.
+ * @param opts - ConfigOpts
+ */
+export const getPublicationLogIterator = async (
+  filter: EventFilter,
+  walkbackBlocks: number,
+  newestBlock?: number,
+  oldestBlock?: number,
+  opts?: ConfigOpts
+): Promise<AsyncPublicationsIterator> => {
+  requireValidWalkback(walkbackBlocks);
+  requireValidBlockRange(newestBlock, oldestBlock);
+  const provider = requireGetProvider(opts);
+  const latestBlock = newestBlock || (await provider.getBlockNumber());
+  const earliestBlock = oldestBlock === undefined ? 0 : oldestBlock;
+  return new AsyncPublicationsIterator({ earliestBlock, latestBlock, walkbackBlocks, filter }, provider);
 };


### PR DESCRIPTION
Problem
=======
We want the ability to fetch Batch Publications asychronously and lazily loaded.
[Finishes #179436295](https://www.pivotaltracker.com/story/show/179436295)

Solution
========
* Create a class AsyncPublicationsIterator that conforms to AsyncIterator (but only in that it has an async next() function)
* Create a function that returns the new iterator after doing some range checking.
* Tests for same

How `next()` works:
1. Calling `next()` on the iterator makes it search for filtered logs on chain, `walkbackBlocks` at a time until it gets results.  
2. Once it gets at least one result it, returns an "IteratorResult" which is an object containing a "done" boolean meaning no more results are left, and the next Publication result, or undefined if there are none.
3. Subsequent calls to `next()` advance the index into the fetched publications until it runs out.  
4. When next has returned the last of the fetched results, calling `next()` repeats the process of walking back until it gets results, or until the `earliestBlock` value has been reached, whichever comes first.

Double Checks:
---------------
- [] Did you update the changelog?
- [X] Any new modules need to be exported? N/A
- [X] Are new methods in the right module?  I think so?
- [X] Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [X] Do you have good documentation on exported methods?

Change summary:
---------------
* New class, AsyncPublicationsIterator
* Creator function for above
* Tests for same

Steps to Verify:
----------------
1. Tests should all pass.
1. You should be able to create and use the AsyncPublicationsIterator when you import this version of the sdk.