### PR TITLE
changed acceptable types in activity content, validation file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Changed accepted MIME types of `audio/mp3` to `audio/mpeg` and removed `image/jpg`
 - Add an AsyncPublicationsIterator, an AsyncIterator which lazily fetches Publication log events from chain and returns them one at a time based on its initial constructor parameters.
 - Updated `tmpl` devDependency to 1.0.5
 - BREAKING: Changed createRegistration to now longer return a user URI and instead returns a Registration Object.

--- a/src/core/activityContent/factories.ts
+++ b/src/core/activityContent/factories.ts
@@ -232,7 +232,7 @@ export const createAudioAttachment = (
  * object.
  *
  * @param href      - The URL of the file
- * @param mediaType - The MIME type of the file
+ * @param mediaType - The MIME type of the file (see SUPPORTED_AUDIO_MEDIA_TYPES within validation.ts)
  * @param hash      - An ActivityContentHash object to authenticate the file
  * @param options - Overrides any default fields for the ActivityContentAudioLink
  * @returns An ActivityContentAudioLink object
@@ -273,7 +273,7 @@ export const createImageAttachment = (
  * object.
  *
  * @param href      - The URL of the file
- * @param mediaType - The MIME type of the file
+ * @param mediaType - The MIME type of the file (see SUPPORTED_IMAGE_MEDIA_TYPES within validation.ts)
  * @param hash      - An ActivityContentHash object to authenticate the file
  * @param options - Overrides any default fields for the ActivityContentImageLink
  * @returns An ActivityContentImageLink object
@@ -314,7 +314,7 @@ export const createVideoAttachment = (
  * object.
  *
  * @param href      - The URL of the file
- * @param mediaType - The MIME type of the file
+ * @param mediaType - The MIME type of the file (see SUPPORTED_VIDEO_MEDIA_TYPES within validation.ts)
  * @param hash      - An ActivityContentHash object to authenticate the file
  * @param options - Overrides any default fields for the ActivityContentVideoLink
  * @returns An ActivityContentVideoLink object

--- a/src/core/activityContent/validation.test.ts
+++ b/src/core/activityContent/validation.test.ts
@@ -31,7 +31,7 @@ describe("activity content validations", () => {
               {
                 type: "Link",
                 href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
-                mediaType: "image/jpg",
+                mediaType: "image/jpeg",
                 hash: [
                   {
                     algorithm: "keccak256",
@@ -58,7 +58,7 @@ describe("activity content validations", () => {
               {
                 type: "Link",
                 href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
-                mediaType: "image/jpg",
+                mediaType: "image/jpeg",
                 hash: "this should be an array",
               },
             ],
@@ -97,7 +97,7 @@ describe("activity content validations", () => {
               {
                 type: "Link",
                 href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
-                mediaType: "image/jpg",
+                mediaType: "image/jpeg",
                 hash: [
                   {
                     algorithm: "keccak256",
@@ -186,7 +186,7 @@ describe("activity content validations", () => {
                 type: "Link",
                 name: "this is fine",
                 href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
-                mediaType: "image/jpg",
+                mediaType: "image/jpeg",
                 hash: [
                   {
                     algorithm: "keccak256",
@@ -276,7 +276,7 @@ describe("activity content validations", () => {
                 {
                   type: "Link",
                   href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
-                  mediaType: "image/jpg",
+                  mediaType: "image/jpeg",
                   hash: [
                     {
                       algorithm: "keccak256",
@@ -449,7 +449,7 @@ describe("activity content validations", () => {
             {
               type: "Link",
               href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
-              mediaType: "image/jpg",
+              mediaType: "image/jpeg",
               hash: [
                 {
                   algorithm: "keccak256",
@@ -498,7 +498,7 @@ describe("activity content validations", () => {
             {
               type: "Link",
               href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
-              mediaType: "image/jpg",
+              mediaType: "image/jpeg",
               hash: [
                 {
                   algorithm: "keccak256",
@@ -607,7 +607,7 @@ describe("activity content validations", () => {
                 {
                   type: "Link",
                   href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
-                  mediaType: "image/jpg",
+                  mediaType: "image/jpeg",
                   hash: [
                     {
                       algorithm: "keccak256",
@@ -777,7 +777,7 @@ describe("activity content validations", () => {
             {
               type: "Link",
               href: "https://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
-              mediaType: "image/jpg",
+              mediaType: "image/jpeg",
               hash: [
                 {
                   algorithm: "keccak256",
@@ -827,7 +827,7 @@ describe("activity content validations", () => {
               {
                 type: "Link",
                 href: "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.jpg",
-                mediaType: "image/jpg",
+                mediaType: "image/jpeg",
                 hash: [
                   {
                     algorithm: "keccak256",
@@ -894,7 +894,7 @@ describe("activity content validations", () => {
             icon: [
               {
                 type: "Link",
-                mediaType: "image/jpg",
+                mediaType: "image/jpeg",
                 href: "https://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
               },
             ],
@@ -974,7 +974,7 @@ describe("activity content validations", () => {
                 {
                   type: "Link",
                   href: "https://upload.wikimedia.org/wikipedia/commons/a/ae/Mccourt.jpg",
-                  mediaType: "image/jpg",
+                  mediaType: "image/jpeg",
                   hash: [
                     {
                       algorithm: "keccak256",
@@ -1148,7 +1148,7 @@ describe("activity content validations", () => {
             {
               type: "Link",
               href: "https://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
-              mediaType: "image/jpg",
+              mediaType: "image/jpeg",
               hash: [
                 {
                   algorithm: "keccak256",
@@ -1221,7 +1221,7 @@ describe("activity content validations", () => {
             icon: [
               {
                 type: "Link",
-                mediaType: "image/jpg",
+                mediaType: "image/jpeg",
                 href: "https://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
                 hash: [
                   {
@@ -1243,7 +1243,7 @@ describe("activity content validations", () => {
             icon: [
               {
                 type: "Link",
-                mediaType: "image/jpg",
+                mediaType: "image/jpeg",
                 href: "https://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
                 hash: [
                   {
@@ -1265,7 +1265,7 @@ describe("activity content validations", () => {
             icon: [
               {
                 type: "Link",
-                mediaType: "image/jpg",
+                mediaType: "image/jpeg",
                 href: "ftp://pbs.twimg.com/profile_images/847818629840228354/VXyQHfn0_400x400.jpg",
                 hash: [
                   {

--- a/src/core/activityContent/validation.ts
+++ b/src/core/activityContent/validation.ts
@@ -32,13 +32,7 @@ const DURATION_REGEX = /^-?P(([0-9]+Y)?([0-9]+M)?([0-9]+D)?(T([0-9]+H)?([0-9]+M)
 const HASH_REGEX = /^0x[0-9A-Fa-f]{64}$/;
 const SUPPORTED_ALGORITHMS = ["keccak256"];
 const SUPPORTED_AUDIO_MEDIA_TYPES = ["audio/mpeg", "audio/ogg", "audio/webm"];
-const SUPPORTED_IMAGE_MEDIA_TYPES = [
-  "image/jpeg",
-  "image/png",
-  "image/svg+xml",
-  "image/webp",
-  "image/gif",
-];
+const SUPPORTED_IMAGE_MEDIA_TYPES = ["image/jpeg", "image/png", "image/svg+xml", "image/webp", "image/gif"];
 const SUPPORTED_VIDEO_MEDIA_TYPES = ["video/mpeg", "video/ogg", "video/webm", "video/H256", "video/mp4"];
 
 const invalidRecordMessage = (extra?: string): string => {

--- a/src/core/activityContent/validation.ts
+++ b/src/core/activityContent/validation.ts
@@ -31,10 +31,9 @@ const HREF_REGEX = /^https?:\/\/.+/;
 const DURATION_REGEX = /^-?P(([0-9]+Y)?([0-9]+M)?([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+(\.[0-9]+)?S)?)?)+$/;
 const HASH_REGEX = /^0x[0-9A-Fa-f]{64}$/;
 const SUPPORTED_ALGORITHMS = ["keccak256"];
-const SUPPORTED_AUDIO_MEDIA_TYPES = ["audio/mp3", "audio/ogg", "audio/webm"];
+const SUPPORTED_AUDIO_MEDIA_TYPES = ["audio/mpeg", "audio/ogg", "audio/webm"];
 const SUPPORTED_IMAGE_MEDIA_TYPES = [
   "image/jpeg",
-  "image/jpg",
   "image/png",
   "image/svg+xml",
   "image/webp",


### PR DESCRIPTION
Problem
=======
[Github issue #126 within spec](https://github.com/LibertyDSNP/spec/issues/126)
The sdk should reflect the changes made to the spec

Change summary:
---------------
- Changed accepted type within activitycontent/validation of audio/mp3 -> audip/mpeg
- Removed accepted type of image/jpg

