### PR TITLE
Update naming of DSNP Announcement URI to DSNP Content URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   NPM module. All previous modules that references the activity content folder
   now wrap the activity content NPM package
   (generators/activityContentGenerators, content).
+- BREAKING: Replaced `isDSNPAnnouncementURI` with `isDSNPContentURI` (DIP-148)
+- BREAKING: Replaced Type Name `DSNPAnnouncementURI` with `DSNPContentURI` (DIP-148)
+- BREAKING: Replaced `buildDSNPAnnouncementURI` with `buildDSNPContentURI` (DIP-148)
+- BREAKING: Replaced `parseDSNPAnnouncementURI` with `parseDSNPContentURI` (DIP-148)
+- BREAKING: Replaced `InvalidAnnouncementUriError` with `InvalidContentUriError` (DIP-148)
 
 ## [3.0.3] - 2021-09-15
 ### Added
@@ -25,7 +30,7 @@
 - Better cleaner build (removed multimodule script need, dist package directory, and better package.json)
 
 ### Removed
-- Internal package `dist` structure. If you were previously importing out of `@dsnp/sdk/dist`, that will need to be updated to the correct export. 
+- Internal package `dist` structure. If you were previously importing out of `@dsnp/sdk/dist`, that will need to be updated to the correct export.
 
 ## [3.0.2] - 2021-09-02
 ### Added
@@ -38,7 +43,7 @@
 
 ## [3.0.1] - 2021-08-27
 ### Added
-- sdk.core.batch.readFile will now await `doReadRow` 
+- sdk.core.batch.readFile will now await `doReadRow`
 
 ## [3.0.0] - 2021-08-25
 ### Changed
@@ -76,7 +81,7 @@
 - sdk.convertBigNumberToDSNPUserId: Not supporting BigNumber anymore
 - sdk.convertDSNPUserIdOrURIToBigNumber: Not supporting BigNumber anymore
 - sdk.convertBigNumberToDSNPUserURI: Not supporting BigNumber anymore
-- Removed sdk.convertDSNPUserURIToDSNPUserId: Just use convertToDSNPUserId and convertToDSNPUserURI 
+- Removed sdk.convertDSNPUserURIToDSNPUserId: Just use convertToDSNPUserId and convertToDSNPUserURI
 
 ## [2.1.2] - 2021-08-20
 ### fixed

--- a/src/content.test.ts
+++ b/src/content.test.ts
@@ -186,9 +186,7 @@ describe("content", () => {
 
       describe("with an invalid inReplyTo Id", () => {
         it("throws InvalidContentUriError", async () => {
-          await expect(content.reply(noteObject, "dsnp://badbadbad/badbadbad")).rejects.toThrow(
-            InvalidContentUriError
-          );
+          await expect(content.reply(noteObject, "dsnp://badbadbad/badbadbad")).rejects.toThrow(InvalidContentUriError);
         });
       });
 

--- a/src/content.test.ts
+++ b/src/content.test.ts
@@ -15,7 +15,7 @@ import {
 import { MissingSignerConfigError, MissingStoreConfigError, MissingFromIdConfigError } from "./core/config";
 import { createCloneProxy } from "./core/contracts/identity";
 import * as registry from "./core/contracts/registry";
-import { InvalidAnnouncementUriError } from "./core/identifiers";
+import { InvalidContentUriError } from "./core/identifiers";
 import { hash } from "./core/utilities";
 import { revertHardhat, snapshotHardhat, setupSnapshot } from "./test/hardhatRPC";
 import { setupConfig } from "./test/sdkTestConfig";
@@ -185,9 +185,9 @@ describe("content", () => {
       });
 
       describe("with an invalid inReplyTo Id", () => {
-        it("throws InvalidAnnouncementUriError", async () => {
+        it("throws InvalidContentUriError", async () => {
           await expect(content.reply(noteObject, "dsnp://badbadbad/badbadbad")).rejects.toThrow(
-            InvalidAnnouncementUriError
+            InvalidContentUriError
           );
         });
       });

--- a/src/content.ts
+++ b/src/content.ts
@@ -20,7 +20,7 @@ import {
   SignedReplyAnnouncement,
   SignedTombstoneAnnouncement,
 } from "./core/announcements";
-import { isDSNPAnnouncementURI, DSNPAnnouncementURI, InvalidAnnouncementUriError } from "./core/identifiers";
+import { isDSNPContentURI, DSNPContentURI, InvalidContentUriError } from "./core/identifiers";
 import { hash } from "./core/utilities";
 
 /**
@@ -75,19 +75,19 @@ export const broadcast = async (
  * Thrown if the from id is not configured.
  * @throws {@link InvalidActivityContentError}
  * Thrown if the provided activity content object is not valid.
- * @throws {@link InvalidAnnouncementUriError}
- * Thrown if the provided inReplyTo Announcement Uri is invalid.
+ * @throws {@link InvalidContentUriError}
+ * Thrown if the provided inReplyTo Content Uri is invalid.
  * @param contentObject - The activity content object with which to reply
- * @param inReplyTo - The DSNP Announcement Uri of the announcement that this announcement is in reply to
+ * @param inReplyTo - The DSNP Content Uri of the announcement that this announcement is in reply to
  * @param opts - Optional. Configuration overrides, such as from address, if any
  * @returns A Signed Reply Announcement ready for inclusion in a batch
  */
 export const reply = async (
   contentObject: ActivityContentNote,
-  inReplyTo: DSNPAnnouncementURI,
+  inReplyTo: DSNPContentURI,
   opts?: ConfigOpts
 ): Promise<SignedReplyAnnouncement> => {
-  if (!isDSNPAnnouncementURI(inReplyTo)) throw new InvalidAnnouncementUriError(inReplyTo);
+  if (!isDSNPContentURI(inReplyTo)) throw new InvalidContentUriError(inReplyTo);
 
   requireValidActivityContentNote(contentObject);
   const content = JSON.stringify(contentObject);
@@ -114,21 +114,21 @@ export const reply = async (
  * Thrown if the signer is not configured.
  * @throws {@link MissingFromIdConfigError}
  * Thrown if the from id is not configured.
- * @throws {@link InvalidAnnouncementUriError}
+ * @throws {@link InvalidContentUriError}
  * Thrown if the provided inReplyTo DSNP Message Id is invalid.
  * @throws {@link InvalidEmojiStringError}
  * Thrown if the emoji provided is invalid.
  * @param emoji - The emoji with which to react
- * @param inReplyTo - The DSNP Announcement Uri of the announcement to which to react
+ * @param inReplyTo - The DSNP Content Uri of the announcement to which to react
  * @param opts - Optional. Configuration overrides, such as from address, if any
  * @returns A Signed Reaction Announcement ready for inclusion in a batch
  */
 export const react = async (
   emoji: string,
-  inReplyTo: DSNPAnnouncementURI,
+  inReplyTo: DSNPContentURI,
   opts?: ConfigOpts
 ): Promise<SignedReactionAnnouncement> => {
-  if (!isDSNPAnnouncementURI(inReplyTo)) throw new InvalidAnnouncementUriError(inReplyTo);
+  if (!isDSNPContentURI(inReplyTo)) throw new InvalidContentUriError(inReplyTo);
   if (!isValidEmoji(emoji)) throw new InvalidEmojiStringError(emoji);
 
   const currentFromURI = requireGetCurrentFromURI(opts);
@@ -187,7 +187,7 @@ export const profile = async (
  * Thrown if the signer is not configured.
  * @throws {@link MissingFromIdConfigError}
  * Thrown if the from id is not configured.
- * @throws {@link InvalidAnnouncementUriError}
+ * @throws {@link InvalidContentUriError}
  * Thrown if the provided inReplyTo DSNP Message Id is invalid.
  * @throws {@link InvalidTombstoneAnnouncementTypeError}
  * Thrown if the target type provided for the tombstone is invalid.

--- a/src/core/announcements/factories.ts
+++ b/src/core/announcements/factories.ts
@@ -1,4 +1,4 @@
-import { convertToDSNPUserId, DSNPAnnouncementURI, DSNPUserId, DSNPUserURI } from "../identifiers";
+import { convertToDSNPUserId, DSNPContentURI, DSNPUserId, DSNPUserURI } from "../identifiers";
 import { HexString } from "../../types/Strings";
 import { createdAtOrNow } from "../utilities";
 
@@ -43,14 +43,14 @@ type BroadcastFields = {
 type ReplyFields = {
   announcementType: AnnouncementType.Reply;
   contentHash: HexString;
-  inReplyTo: DSNPAnnouncementURI;
+  inReplyTo: DSNPContentURI;
   url: string;
 };
 
 type ReactionFields = {
   announcementType: AnnouncementType.Reaction;
   emoji: string;
-  inReplyTo: DSNPAnnouncementURI;
+  inReplyTo: DSNPContentURI;
 };
 
 type GraphChangeFields = {
@@ -128,12 +128,12 @@ export type ReplyAnnouncement = TypedAnnouncement<AnnouncementType.Reply>;
 
 /**
  * createReply() generates a reply announcement from a given URL, hash and
- * announcement uri.
+ * content uri.
  *
  * @param fromURI   - The id of the user from whom the announcement is posted
  * @param url       - The URL of the activity content to reference
  * @param hash      - The hash of the content at the URL
- * @param inReplyTo - The DSNP Announcement Uri of the parent announcement
+ * @param inReplyTo - The DSNP Content Uri of the parent announcement
  * @param createdAt - Optional. The createdAt timestamp of the announcement as a BigInt of milliseconds since UNIX epoch
  * @returns A ReplyAnnouncement
  */
@@ -141,7 +141,7 @@ export const createReply = (
   fromURI: DSNPUserURI,
   url: string,
   hash: HexString,
-  inReplyTo: DSNPAnnouncementURI,
+  inReplyTo: DSNPContentURI,
   createdAt?: bigint
 ): ReplyAnnouncement => ({
   announcementType: AnnouncementType.Reply,
@@ -159,18 +159,18 @@ export type ReactionAnnouncement = TypedAnnouncement<AnnouncementType.Reaction>;
 
 /**
  * createReaction() generates a reaction announcement from a given URL, hash and
- * announcement uri.
+ * content uri.
  *
  * @param fromURI   - The id of the user from whom the announcement is posted
  * @param emoji     - The emoji to respond with
- * @param inReplyTo - The DSNP Announcement Uri of the parent announcement
+ * @param inReplyTo - The DSNP Content Uri of the parent announcement
  * @param createdAt - Optional. The createdAt timestamp of the announcement as a BigInt of milliseconds since UNIX epoch
  * @returns A ReactionAnnouncement
  */
 export const createReaction = (
   fromURI: DSNPUserURI,
   emoji: string,
-  inReplyTo: DSNPAnnouncementURI,
+  inReplyTo: DSNPContentURI,
   createdAt?: bigint
 ): ReactionAnnouncement => ({
   announcementType: AnnouncementType.Reaction,

--- a/src/core/announcements/validation.ts
+++ b/src/core/announcements/validation.ts
@@ -13,7 +13,7 @@ import {
   ReactionAnnouncement,
   ProfileAnnouncement,
 } from "./factories";
-import { isDSNPUserId, isDSNPAnnouncementURI } from "../identifiers";
+import { isDSNPUserId, isDSNPContentURI } from "../identifiers";
 import { convertSignedAnnouncementToAnnouncement } from "./services";
 import { isRecord, isString, isNumber, isBigInt } from "../utilities/validation";
 
@@ -149,7 +149,7 @@ export const isReplyAnnouncement = (obj: unknown): obj is ReplyAnnouncement => {
   if (!isBigInt(obj["createdAt"])) return false;
   if (!isString(obj["url"])) return false;
   if (!isString(obj["contentHash"])) return false;
-  if (!isDSNPAnnouncementURI(obj["inReplyTo"])) return false;
+  if (!isDSNPContentURI(obj["inReplyTo"])) return false;
 
   return true;
 };
@@ -166,7 +166,7 @@ export const isReactionAnnouncement = (obj: unknown): obj is ReactionAnnouncemen
   if (!isDSNPUserId(obj["fromId"])) return false;
   if (!isBigInt(obj["createdAt"])) return false;
   if (!isValidEmoji(obj["emoji"])) return false;
-  if (!isDSNPAnnouncementURI(obj["inReplyTo"])) return false;
+  if (!isDSNPContentURI(obj["inReplyTo"])) return false;
 
   return true;
 };

--- a/src/core/identifiers/errors.ts
+++ b/src/core/identifiers/errors.ts
@@ -10,14 +10,14 @@ export class IdentifierError extends DSNPError {
 }
 
 /**
- * InvalidAnnouncementUriError indicates an improperly formatted DSNP announcement
+ * InvalidContentUriError indicates an improperly formatted DSNP announcement
  * identifier.
  */
-export class InvalidAnnouncementUriError extends IdentifierError {
-  AnnouncementUri: string;
+export class InvalidContentUriError extends IdentifierError {
+  contentUri: string;
 
-  constructor(AnnouncementUri: string) {
-    super(`Invalid Announcement Uri: ${AnnouncementUri}`);
-    this.AnnouncementUri = AnnouncementUri;
+  constructor(contentUri: string) {
+    super(`Invalid Content Uri: ${contentUri}`);
+    this.contentUri = contentUri;
   }
 }

--- a/src/core/identifiers/identifiers.test.ts
+++ b/src/core/identifiers/identifiers.test.ts
@@ -1,12 +1,12 @@
 import {
-  buildDSNPAnnouncementURI,
+  buildDSNPContentURI,
   convertToDSNPUserId,
   convertToDSNPUserURI,
-  isDSNPAnnouncementURI,
+  isDSNPContentURI,
   isDSNPUserURI,
-  parseDSNPAnnouncementURI,
+  parseDSNPContentURI,
 } from "./identifiers";
-import { InvalidAnnouncementUriError } from "./errors";
+import { InvalidContentUriError } from "./errors";
 import { BigNumber } from "ethers";
 
 describe("identifiers", () => {
@@ -34,37 +34,37 @@ describe("identifiers", () => {
     }
   });
 
-  describe("isDSNPAnnouncementURI", () => {
-    const validDSNPAnnouncementURIs = [
+  describe("isDSNPContentURI", () => {
+    const validDSNPContentURIs = [
       "dsnp://11611200575284957000/0xa123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", // Lowercase
     ];
 
-    const invalidDSNPAnnouncementURIs = [
+    const invalidDSNPContentURIs = [
       "dsnp://11611200575284957000/0xa123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF", // Uppercase
       "dsnp://0x0123456789abcdef/0xa123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", // 0x on user
       "dsnp://11611200575284957000/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", // No 0x on announcement
       "dsnp://badwolf/0xa123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", // Bad user URI
-      "dsnp://11611200575284957000/0xbadwolf", // Bad announcement URI
+      "dsnp://11611200575284957000/0xbadwolf", // Bad content uri
       "dsnp://184467440737095516150/0xa123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", // User URI too long
-      "dsnp://11611200575284957000/0xa123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdefa", // Announcement Uri too short
+      "dsnp://11611200575284957000/0xa123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdefa", // Content Uri too short
     ];
 
-    for (const id of validDSNPAnnouncementURIs) {
+    for (const id of validDSNPContentURIs) {
       it(`returns true for "${id}"`, () => {
-        expect(isDSNPAnnouncementURI(id)).toEqual(true);
+        expect(isDSNPContentURI(id)).toEqual(true);
       });
     }
 
-    for (const id of invalidDSNPAnnouncementURIs) {
+    for (const id of invalidDSNPContentURIs) {
       it(`returns false for "${id}"`, () => {
-        expect(isDSNPAnnouncementURI(id)).toEqual(false);
+        expect(isDSNPContentURI(id)).toEqual(false);
       });
     }
   });
 
-  describe("buildDSNPAnnouncementURI", () => {
-    it("returns valid DSNP Announcement Uris", () => {
-      const id = buildDSNPAnnouncementURI(
+  describe("buildDSNPContentURI", () => {
+    it("returns valid DSNP Content Uris", () => {
+      const id = buildDSNPContentURI(
         "11611200575284957000",
         "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
       );
@@ -73,8 +73,8 @@ describe("identifiers", () => {
       );
     });
 
-    it("returns valid DSNP Announcement Uri with a DSNP Uri", () => {
-      const id = buildDSNPAnnouncementURI(
+    it("returns valid DSNP Content Uri with a DSNP Uri", () => {
+      const id = buildDSNPContentURI(
         "dsnp://11611200575284957000",
         "0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
       );
@@ -84,9 +84,9 @@ describe("identifiers", () => {
     });
   });
 
-  describe("parseDSNPAnnouncementURI", () => {
+  describe("parseDSNPContentURI", () => {
     it("returns userId and contentHash", () => {
-      const id = parseDSNPAnnouncementURI(
+      const id = parseDSNPContentURI(
         "dsnp://11611200575284957000/0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
       );
       expect(id).toEqual({
@@ -138,7 +138,7 @@ describe("identifiers", () => {
     it("throws for invalid uri", () => {
       expect(() => {
         convertToDSNPUserId("dsnp://034b");
-      }).toThrow(InvalidAnnouncementUriError);
+      }).toThrow(InvalidContentUriError);
     });
   });
 });

--- a/src/core/identifiers/identifiers.ts
+++ b/src/core/identifiers/identifiers.ts
@@ -102,10 +102,7 @@ export const convertToDSNPUserURI = (value: unknown): DSNPUserURI => {
  * @param contentHash - The content hash of the announcement posted by the user
  * @returns A DSNP Content Uri for the given announcement
  */
-export const buildDSNPContentURI = (
-  userIdOrUri: DSNPUserId | DSNPUserURI,
-  contentHash: HexString
-): DSNPContentURI => {
+export const buildDSNPContentURI = (userIdOrUri: DSNPUserId | DSNPUserURI, contentHash: HexString): DSNPContentURI => {
   return `dsnp://${convertToDSNPUserId(userIdOrUri)}/${contentHash}`;
 };
 
@@ -116,9 +113,7 @@ export const buildDSNPContentURI = (
  * @param contentUri - A DSNP Announcement Id
  * @returns the userId and contentHash from the Content Uri
  */
-export const parseDSNPContentURI = (
-  contentUri: DSNPContentURI
-): { userId: DSNPUserId; contentHash: HexString } => {
+export const parseDSNPContentURI = (contentUri: DSNPContentURI): { userId: DSNPUserId; contentHash: HexString } => {
   const [userId, contentHash] = contentUri.replace("dsnp://", "").split("/");
   return { userId: BigInt(userId), contentHash };
 };

--- a/src/core/identifiers/identifiers.ts
+++ b/src/core/identifiers/identifiers.ts
@@ -1,24 +1,24 @@
 import { isBigInt, isString } from "../utilities/validation";
 import { HexString } from "../../types/Strings";
 import { BigNumber } from "ethers";
-import { InvalidAnnouncementUriError } from "./errors";
+import { InvalidContentUriError } from "./errors";
 
 const DSNP_SCHEMA_REGEX = /^dsnp:\/\//i;
 
 /**
- * DSNPAnnouncementURI represents a DSNP Announcement Uri following the DSNP
+ * DSNPContentURI represents a DSNP Content Uri following the DSNP
  * [Identifiers](https://github.com/LibertyDSNP/spec/blob/main/pages/Identifiers.md)
  * specification.
  */
-export type DSNPAnnouncementURI = string;
+export type DSNPContentURI = string;
 
 /**
- * isDSNPAnnouncementURI() validates a given string as a DSNPAnnouncementURI.
+ * isDSNPContentURI() validates a given string as a DSNPContentURI.
  *
  * @param id - The object to validate
- * @returns True of false depending on whether the string is a valid DSNPAnnouncementURI
+ * @returns True of false depending on whether the string is a valid DSNPContentURI
  */
-export const isDSNPAnnouncementURI = (id: unknown): id is DSNPAnnouncementURI => {
+export const isDSNPContentURI = (id: unknown): id is DSNPContentURI => {
   if (!isString(id)) return false;
   return id.match(/^dsnp:\/\/[0-9]{1,20}\/0x[0-9a-f]{64}$/) !== null;
 };
@@ -76,7 +76,7 @@ export const convertToDSNPUserId = (value: unknown): DSNPUserId => {
     if (isDSNPUserURI(value)) {
       return BigInt(value.replace(DSNP_SCHEMA_REGEX, ""));
     } else {
-      throw new InvalidAnnouncementUriError(value);
+      throw new InvalidContentUriError(value);
     }
   }
   // Cast or throw?
@@ -95,30 +95,30 @@ export const convertToDSNPUserURI = (value: unknown): DSNPUserURI => {
 };
 
 /**
- * buildDSNPAnnouncementURI() takes a DSNP user id or URI and a content hash and
- * returns a DSNP Announcement Uri.
+ * buildDSNPContentURI() takes a DSNP user id or URI and a content hash and
+ * returns a DSNP Content Uri.
  *
  * @param userIdOrUri - The DSNP user id or URI of the announcing user
  * @param contentHash - The content hash of the announcement posted by the user
- * @returns A DSNP Announcement Uri for the given announcement
+ * @returns A DSNP Content Uri for the given announcement
  */
-export const buildDSNPAnnouncementURI = (
+export const buildDSNPContentURI = (
   userIdOrUri: DSNPUserId | DSNPUserURI,
   contentHash: HexString
-): DSNPAnnouncementURI => {
+): DSNPContentURI => {
   return `dsnp://${convertToDSNPUserId(userIdOrUri)}/${contentHash}`;
 };
 
 /**
- * parseDSNPAnnouncementURI() takes a DSNP Announcement Uri and returns the
+ * parseDSNPContentURI() takes a DSNP Content Uri and returns the
  * userId and contentHash.
  *
- * @param announcementUri - A DSNP Announcement Id
- * @returns the userId and contentHash from the Announcement Uri
+ * @param contentUri - A DSNP Announcement Id
+ * @returns the userId and contentHash from the Content Uri
  */
-export const parseDSNPAnnouncementURI = (
-  announcementUri: DSNPAnnouncementURI
+export const parseDSNPContentURI = (
+  contentUri: DSNPContentURI
 ): { userId: DSNPUserId; contentHash: HexString } => {
-  const [userId, contentHash] = announcementUri.replace("dsnp://", "").split("/");
+  const [userId, contentHash] = contentUri.replace("dsnp://", "").split("/");
   return { userId: BigInt(userId), contentHash };
 };

--- a/src/test/importTest/index.ts
+++ b/src/test/importTest/index.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 
 import sdk from "@dsnp/sdk";
 import { generators } from "@dsnp/sdk";
-import { buildDSNPAnnouncementURI } from "@dsnp/sdk/core/identifiers";
+import { buildDSNPContentURI } from "@dsnp/sdk/core/identifiers";
 import { subscribeToBatchPublications } from "@dsnp/sdk/core/contracts/subscription";
 
 Object.entries({
@@ -11,7 +11,7 @@ Object.entries({
   generators,
   dsnpGenerators: generators.dsnp.generateBroadcast,
   contractSubscription: subscribeToBatchPublications,
-  buildDSNPAnnouncementURI: buildDSNPAnnouncementURI,
+  buildDSNPContentURI: buildDSNPContentURI,
 }).forEach(([key, value]) => {
   assert.notStrictEqual(value, undefined, `Was unable to import ${key}`);
 });


### PR DESCRIPTION
Problem
=======
Update the naming of DSNP Announcement URI to DSNP Content URI per https://github.com/LibertyDSNP/spec/issues/148

Double Checks:
---------------
- [x] Did you update the changelog?
- [x] Any new modules need to be exported?
- [x] Are new methods in the right module?
- [x] Are new methods/modules in core or not (i.e. porcelain or plumbing)?
- [x] Do you have good documentation on exported methods?

Change summary:
---------------
- Replaced `isDSNPAnnouncementURI` with `isDSNPContentURI`
- Replaced Type Name `DSNPAnnouncementURI` with `DSNPContentURI`
- Replaced `buildDSNPAnnouncementURI` with `buildDSNPContentURI`
- Replaced `parseDSNPAnnouncementURI` with `parseDSNPContentURI`
- Replaced `InvalidAnnouncementUriError` with `InvalidContentUriError`

Steps to Verify:
----------------
1. Search for Announcement URI in all forms and don't find any in the code